### PR TITLE
Fix instructions to run npm run start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo npm run patch:hosts
 
 1. ```npm install```
 
-2. ```PROXY=true npm run start:beta```
+2. ```PROXY=true npm run start``` choose stage and then beta
 
 3. Open browser in URL listed in the terminal output
 


### PR DESCRIPTION
Not sure If it is a requirement for mac, but for me running:
`PROXY=true npm run start:beta`

 resulted in: 

```
npm ERR! missing script: start:beta
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     start
```

@amirfefer  Maybe we should add it as a different option? 
