### PR TITLE
Add simple global state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-query": "^3.39.1",
         "react-redux": "7.2.4",
         "react-router-dom": "5.2.0",
+        "react-tracked": "^1.7.9",
         "redux": "4.1.0",
         "redux-logger": "3.0.6",
         "redux-promise-middleware": "6.1.2"
@@ -15066,6 +15067,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.1.0.tgz",
+      "integrity": "sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -15288,6 +15294,48 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "node_modules/react-tracked": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.9.tgz",
+      "integrity": "sha512-axBJegjdQbsHizZ0DtEpM4g3sDW1SF5mq9j9bk77mRbcFR+OeBR4vLAqO7E6/DOPeGdDDqLBBIFBy5tmjnOd+A==",
+      "dependencies": {
+        "proxy-compare": "2.1.0",
+        "use-context-selector": "1.3.10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-tracked/node_modules/use-context-selector": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.10.tgz",
+      "integrity": "sha512-xprS9YQ0F56IPTOjev+Lm+TWZD7Pa20+slBeaClt4YtOOoHKFOF3A9Cfr7LDcX2QIZ9VTyxXCnA6/WhL4Cm47g==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-pkg": {
@@ -30913,6 +30961,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-compare": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.1.0.tgz",
+      "integrity": "sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -31088,6 +31141,23 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-tracked": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.9.tgz",
+      "integrity": "sha512-axBJegjdQbsHizZ0DtEpM4g3sDW1SF5mq9j9bk77mRbcFR+OeBR4vLAqO7E6/DOPeGdDDqLBBIFBy5tmjnOd+A==",
+      "requires": {
+        "proxy-compare": "2.1.0",
+        "use-context-selector": "1.3.10"
+      },
+      "dependencies": {
+        "use-context-selector": {
+          "version": "1.3.10",
+          "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.10.tgz",
+          "integrity": "sha512-xprS9YQ0F56IPTOjev+Lm+TWZD7Pa20+slBeaClt4YtOOoHKFOF3A9Cfr7LDcX2QIZ9VTyxXCnA6/WhL4Cm47g==",
+          "requires": {}
+        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-query": "^3.39.1",
     "react-redux": "7.2.4",
     "react-router-dom": "5.2.0",
+    "react-tracked": "^1.7.9",
     "redux": "4.1.0",
     "redux-logger": "3.0.6",
     "redux-promise-middleware": "6.1.2"

--- a/src/Components/Common/GlobalState/index.js
+++ b/src/Components/Common/GlobalState/index.js
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import { createContainer } from 'react-tracked';
+import initialGlobalState from './initialState';
+
+const useSharedState = () => useState(initialGlobalState);
+
+export const { Provider: GlobalStateProvider, useTracked: useGlobalState } =
+  createContainer(useSharedState);

--- a/src/Components/Common/GlobalState/initialState.js
+++ b/src/Components/Common/GlobalState/initialState.js
@@ -1,0 +1,5 @@
+const initialGlobalState = {
+  chosenSource: undefined,
+};
+
+export default initialGlobalState;

--- a/src/Components/SourcesDropdown/index.js
+++ b/src/Components/SourcesDropdown/index.js
@@ -9,9 +9,11 @@ import { useQuery } from 'react-query';
 
 import { SOURCES_QUERY_KEY } from '../../API/consts';
 import { fetchSourcesList } from '../../API';
+import { useGlobalState } from '../Common/GlobalState';
 
 const SourcesDropdown = () => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [globalState, setGlobalState] = useGlobalState();
 
   const {
     isLoading,
@@ -31,9 +33,9 @@ const SourcesDropdown = () => {
     onFocus();
   };
 
-  // TODO: add the chosen source to an global/external state
   const sourcesDetails = (id) => {
-    console.log(`${id} was chosen`);
+    setGlobalState((prevState) => ({ ...prevState, chosenSource: id }));
+    console.log(`${globalState.chosenSource} was chosen`);
   };
   const dropdownItemsMapper = () => {
     if (isLoading)
@@ -62,6 +64,7 @@ const SourcesDropdown = () => {
   }
 
   return (
+    // TODO: Move the globalProvider to the wizard component
     <Dropdown
       onSelect={onSelect}
       toggle={

--- a/src/mocks/utils.js
+++ b/src/mocks/utils.js
@@ -3,11 +3,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { GlobalStateProvider } from '../Components/Common/GlobalState';
 
 const AllProviders = ({ children }) => {
   const queryClient = new QueryClient();
+
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <GlobalStateProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </GlobalStateProvider>
   );
 };
 


### PR DESCRIPTION
_Depends on #13 and #16 as different commits_ 

This PR adds a simple global state with (react-tracked)[https://react-tracked.js.org]
React Context API has some drawbacks,  it's not performance-wise out of the box, and it might re-render all of the components that consume it and trigger performance issues, this [thread](https://www.basefactor.com/global-state-with-react) explains these drawbacks.

### Doesn't react-query replace the need for a global state? 
Yes and no, react-query has a different approach than the classic redux/store, it represents the server state, while this global state represents some global client's variables that need to be reused by other components.

For example, let's take the `<SourcesDropdown>` -  it represents all the provisioning sources that the user can choose from. `react-query` is responsible for fetching, mutating, and caching the sources list from the server, while this global state addition will store only the `chosenSourcesID` so it can be consumed from other components.




