### PR TITLE
rename globalState to wizardContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # provisioning-frontend
 
-Provisioning frontend service for `cloud.redhat.com`
+Provisioning frontend service for `console.redhat.com`
 
 ## Development
-This project is based on react and uses the `cloud.redhat.com` micro-frontend architecture
+This project is based on react and uses the `console.redhat.com` micro-frontend architecture
 
-[patternfly](https://www.patternfly.org/v4/) - an opinionated UX/UI library for enterprise applications
-[insights-chrome](https://github.com/RedHatInsights/insights-chrome) - a wrapper that provides an api for the global application (menus / auth / etc)
-[react-query](https://react-query.tanstack.com) - Manages the server state
-[react-tracked](https://react-tracked.js.org) - Optimizes re-renders for a global state management
+- [patternfly](https://www.patternfly.org/v4/) - an opinionated UX/UI library for enterprise applications
+- [insights-chrome](https://github.com/RedHatInsights/insights-chrome) - a wrapper that provides an api for the global application (menus / auth / etc)
+- [react-query](https://react-query.tanstack.com) - Manages the server state
+- [react-tracked](https://react-tracked.js.org) - Optimizes re-renders for a global state management 
 
 For further reading see [dev](https://github.com/RHEnVision/provisioning-frontend/blob/main/docs/dev.md)
 

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/extend-expect';
 import { server } from '../src/mocks/server';
 
-// this globally mocks the initial global state, for editing go to GlobalState/__mocks__
-jest.mock('../src/Components/Common/GlobalState/initialState');
+// this globally mocks the initial global state, for editing go to WizardContext/__mocks__
+jest.mock('../src/Components/Common/WizardContext/initialState');
 
 beforeAll(() => server.listen());
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -22,34 +22,36 @@ First have a look in the `API/index.js` to see if there's already a fetch functi
    ```
 2. Add a specific constant or a function for the request's key in `API/keys.js`, this allow caching data and prevents redundant fetching, for further information about creating a query key, see [queries keys docs](https://react-query.tanstack.com/guides/query-keys)
 3. Consume the hook `useQuery` in your component
-   ```js
-     const {
+   
+```js
+    const {
       isLoading,
       isError,
       error,
       data,
-  } = useQuery(MY_QUERY_KEY, fetchSomeList);
-   ```
+    } = useQuery(MY_QUERY_KEY, fetchSomeList);
+```
+
    There are plenty of options to choose from, i.e depended on queries, stale query, caching time, manual triggering, polling, and more. 
    For further reading visit the [useQuery](https://react-query.tanstack.com/reference/useQuery) API
 
-## Client global state
-While the `react-query` replaces the need for managing the server's data state, there's a need to manage a client's global state.
-For implementing a simple global state, we use the native `useState` wrapped by [react-tracked](https://react-tracked.js.org/) which is used for optimizing the DOM and preventing enforce redundant re-renders on global state changes.
+## Wizard Context
+While the `react-query` replaces the need for managing the server's data state, there's a need to manage a client's context.
+For implementing a simple wizard context, we use the native `useState` wrapped by [react-tracked](https://react-tracked.js.org/) which is used for optimizing the DOM and preventing enforce redundant re-renders on context values changes.
 
-### When to use the global state
-As a rule of thumb, if a client state is required in multiple steps (wizard steps), then it makes sense to keep it global (like the native `React.Context` approach), so we won't need to propagate many local state (and setters functions) deeply in the wizard tree. Try to keep the client's state data as primitive as you can (string, number, boolean) for preventing future optimizations issues.
+### When to use the wizard context
+As a rule of thumb, if a client state is required in multiple steps (wizard steps), then it makes sense to store it in a context (like the native `React.Context` approach), so we won't need to propagate many local state (and setters functions) deeply in the wizard tree. Try to keep the context data as primitive as you can (string, number, boolean) for preventing future optimizations issues.
 
 ### How to use it
 ```js
-import { useGlobalState } from '../Common/GlobalState';
+import { useWizardContext } from '../Common/WizardContext';
 
-  const [globalState, setGlobalState] = useGlobalState();
+  const [wizardContext, setWizardContext] = useWizardContext();
 
   clickHandler(id) => {
-    // updating the global state
-    setGlobalState((prevState) => ({ ...prevState, chosenItemID: id }));
+    // updating the context
+    setWizardContext((prevState) => ({ ...prevState, chosenItemID: id }));
 }
-  // using the global state, `data` can be some list from the server's state
-  const chosenItem = data.find(item => item.id === globalState.chosenItemID);
+  // using the context, `data` can be some list from the server's state
+  const chosenItem = data.find(item => item.id === wizardContext.choseItemID);
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,14 +39,14 @@ Sometimes we'd like to override a response handler in a specific test, for examp
 ```
 
 ## Custom render
-In order to access `GlobalState` and `react-query` provider, the `render` function of `testing-library` is altered with a wrapper.
+In order to access `WizardContext` and `react-query` provider, the `render` function of `testing-library` is altered with a wrapper.
 You can import all `testing-library` related functions from `mocks/utils`
 
 ```js
 import { render, fireEvent, screen } from '../../mocks/utils';
 
   test('Loading state', async () => {
-    // the component will be rended with globalState and react-query provider
+    // the component will be rended with wizard context and react-query provider
     render(<Component />)
   }
 ```

--- a/src/Components/Common/GlobalState/__mocks__/initialState.js
+++ b/src/Components/Common/GlobalState/__mocks__/initialState.js
@@ -1,5 +1,0 @@
-const initialGlobalState = {
-  chosenSource: 1,
-};
-
-export default initialGlobalState;

--- a/src/Components/Common/GlobalState/index.js
+++ b/src/Components/Common/GlobalState/index.js
@@ -1,8 +1,0 @@
-import { useState } from 'react';
-import { createContainer } from 'react-tracked';
-import initialGlobalState from './initialState';
-
-const useSharedState = () => useState(initialGlobalState);
-
-export const { Provider: GlobalStateProvider, useTracked: useGlobalState } =
-  createContainer(useSharedState);

--- a/src/Components/Common/WizardContext/__mocks__/initialState.js
+++ b/src/Components/Common/WizardContext/__mocks__/initialState.js
@@ -1,0 +1,5 @@
+const initialWizardContext = {
+  chosenSource: 1,
+};
+
+export default initialWizardContext;

--- a/src/Components/Common/WizardContext/index.js
+++ b/src/Components/Common/WizardContext/index.js
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import { createContainer } from 'react-tracked';
+import initialWizardContext from './initialState';
+
+const useSharedState = () => useState(initialWizardContext);
+
+export const { Provider: WizardProvider, useTracked: useWizardContext } =
+  createContainer(useSharedState);

--- a/src/Components/Common/WizardContext/initialState.js
+++ b/src/Components/Common/WizardContext/initialState.js
@@ -1,7 +1,7 @@
-const initialGlobalState = {
+const initialWizardContext = {
   chosenSource: undefined,
   chosenNumOfInstances: 1,
   chosenInstanceType: undefined,
 };
 
-export default initialGlobalState;
+export default initialWizardContext;

--- a/src/Components/DescriptionListAWS/index.js
+++ b/src/Components/DescriptionListAWS/index.js
@@ -5,13 +5,14 @@ import {
   DescriptionListGroup,
   DescriptionListDescription,
 } from '@patternfly/react-core';
-import { useGlobalState } from '../Common/GlobalState';
+
 import { useQuery } from 'react-query';
 import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
+import { useWizardContext } from '../Common/WizardContext';
 
 const DescriptionListAWS = () => {
-  const [globalState] = useGlobalState();
+  const [wizardContext] = useWizardContext();
   const { error, data: sources } = useQuery(
     SOURCES_QUERY_KEY,
     fetchSourcesList
@@ -23,7 +24,7 @@ const DescriptionListAWS = () => {
   }
 
   const getChosenSourceName = () =>
-    sources.find((source) => source.id === globalState.chosenSource).name;
+    sources.find((source) => source.id === wizardContext.chosenSource).name;
 
   return (
     <DescriptionList isHorizontal>
@@ -40,13 +41,13 @@ const DescriptionListAWS = () => {
       <DescriptionListGroup>
         <DescriptionListTerm>Instance type</DescriptionListTerm>
         <DescriptionListDescription>
-          {globalState.chosenInstanceType}
+          {wizardContext.chosenInstanceType}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Count</DescriptionListTerm>
         <DescriptionListDescription>
-          {globalState.chosenNumOfInstances}
+          {wizardContext.chosenNumOfInstances}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>

--- a/src/Components/InstanceCounter/index.js
+++ b/src/Components/InstanceCounter/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Slider } from '@patternfly/react-core';
-import { useGlobalState } from '../Common/GlobalState';
+import { useWizardContext } from '../Common/WizardContext';
 const MAX_INSTANCES = 45;
 const MIN_INSTANCES = 1;
 
 const InstanceCounter = () => {
-  const [globalState, setGlobalState] = useGlobalState();
+  const [wizardContext, setWizardContext] = useWizardContext();
   const onChange = (value, inputValue, setLocalInputValue) => {
     let newValue;
     if (inputValue === undefined) {
@@ -21,7 +21,7 @@ const InstanceCounter = () => {
         newValue = Math.floor(inputValue);
       }
     }
-    setGlobalState((prevState) => ({
+    setWizardContext((prevState) => ({
       ...prevState,
       chosenNumOfInstances: newValue,
     }));
@@ -30,9 +30,9 @@ const InstanceCounter = () => {
     <Slider
       max={MAX_INSTANCES}
       min={MIN_INSTANCES}
-      value={globalState.chosenNumOfInstances}
+      value={wizardContext.chosenNumOfInstances}
       isInputVisible
-      inputValue={globalState.chosenNumOfInstances}
+      inputValue={wizardContext.chosenNumOfInstances}
       hasTooltipOverThumb
       onChange={onChange}
     />

--- a/src/Components/InstanceTypesSelect/index.js
+++ b/src/Components/InstanceTypesSelect/index.js
@@ -3,22 +3,25 @@ import { Spinner, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
 import { instanceTypesQueryKeys } from '../../API/queryKeys';
 import { fetchInstanceTypesList } from '../../API';
-import { useGlobalState } from '../Common/GlobalState';
+import { useWizardContext } from '../Common/WizardContext';
 
 const InstanceTypesSelect = () => {
-  const [globalState, setGlobalState] = useGlobalState();
+  const [wizardContext, setWizardContext] = useWizardContext();
   const {
     isLoading,
     error,
     data: instanceTypes,
   } = useQuery(
-    instanceTypesQueryKeys(globalState.chosenSource),
-    () => fetchInstanceTypesList(globalState.chosenSource),
-    { enabled: !!globalState.chosenSource }
+    instanceTypesQueryKeys(wizardContext.chosenSource),
+    () => fetchInstanceTypesList(wizardContext.chosenSource),
+    { enabled: !!wizardContext.chosenSource }
   );
 
   const onChange = (name) => {
-    setGlobalState((prevState) => ({ ...prevState, chosenInstanceType: name }));
+    setWizardContext((prevState) => ({
+      ...prevState,
+      chosenInstanceType: name,
+    }));
   };
 
   const selectItemsMapper = () => {
@@ -60,7 +63,7 @@ const InstanceTypesSelect = () => {
       <FormSelect
         onChange={onChange}
         aria-label="Select instance type"
-        value={globalState.chosenInstanceType}
+        value={wizardContext.chosenInstanceType}
       >
         {selectItemsMapper()}
       </FormSelect>

--- a/src/Components/SourcesSelect/index.js
+++ b/src/Components/SourcesSelect/index.js
@@ -4,17 +4,17 @@ import { useQuery } from 'react-query';
 
 import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
-import { useGlobalState } from '../Common/GlobalState';
+import { useWizardContext } from '../Common/WizardContext';
 
 const SourcesSelect = () => {
-  const [globalState, setGlobalState] = useGlobalState();
+  const [wizardContext, setWizardContext] = useWizardContext();
   const { error, data: sources } = useQuery(
     SOURCES_QUERY_KEY,
     fetchSourcesList
   );
 
   const onChange = (value) => {
-    setGlobalState((prevState) => ({ ...prevState, chosenSource: value }));
+    setWizardContext((prevState) => ({ ...prevState, chosenSource: value }));
   };
 
   const selectItemsMapper = () => {
@@ -50,7 +50,7 @@ const SourcesSelect = () => {
 
   return (
     <FormSelect
-      value={globalState.chosenSource}
+      value={wizardContext.chosenSource}
       onChange={onChange}
       aria-label="Select account"
     >

--- a/src/Components/Wizard/index.js
+++ b/src/Components/Wizard/index.js
@@ -3,7 +3,7 @@ import { Wizard } from '@patternfly/react-core';
 import React from 'react';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
-import { GlobalStateProvider } from '../Common/GlobalState';
+import { WizardProvider } from '../Common/WizardContext';
 import APIProvider from '../Common/Query';
 import defaultSteps from './steps';
 import { useDispatch } from 'react-redux';
@@ -33,7 +33,7 @@ const ProvisioningWizard = ({ isOpen, onClose, ...props }) => {
   };
 
   return (
-    <GlobalStateProvider>
+    <WizardProvider>
       <APIProvider>
         <Wizard
           {...props}
@@ -46,7 +46,7 @@ const ProvisioningWizard = ({ isOpen, onClose, ...props }) => {
           onSave={handleAlert}
         />
       </APIProvider>
-    </GlobalStateProvider>
+    </WizardProvider>
   );
 };
 

--- a/src/mocks/utils.js
+++ b/src/mocks/utils.js
@@ -3,15 +3,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { GlobalStateProvider } from '../Components/Common/GlobalState';
+import { WizardProvider } from '../Components/Common/WizardContext';
 
 const AllProviders = ({ children }) => {
   const queryClient = new QueryClient();
 
   return (
-    <GlobalStateProvider>
+    <WizardProvider>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </GlobalStateProvider>
+    </WizardProvider>
   );
 };
 


### PR DESCRIPTION
`GlobalState` can be a confusing term, `WizardContext` describes better the domain