### PR TITLE
Fix console errors during tests

### DIFF
--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import InstanceTypesSelect from '.';
 import { instanceTypeList } from '../../mocks/fixtures/instanceTypes.fixtures';
-import { waitFor, render, fireEvent, screen } from '../../mocks/utils';
+import { render, fireEvent, screen } from '../../mocks/utils';
 
 describe('InstanceTypesSelect', () => {
   test('populate instance types select', async () => {
-    mountSelectAndClick();
+    await mountSelectAndClick();
     const items = await screen.findAllByLabelText('Instance Type item');
     expect(items).toHaveLength(instanceTypeList.length);
   });
 });
 
-const mountSelectAndClick = () => {
+const mountSelectAndClick = async () => {
   render(<InstanceTypesSelect />);
-  waitFor(() => fireEvent.click(screen.getByText(/Select instance type/)));
+  const selectDropdown = await screen.findByText(/Select instance type/);
+  fireEvent.click(selectDropdown);
 };

--- a/src/mocks/fixtures/instanceTypes.fixtures.js
+++ b/src/mocks/fixtures/instanceTypes.fixtures.js
@@ -1,6 +1,6 @@
 export const instanceTypeList = [
   {
-    identifier: 'Instance Type 1',
+    id: 'Instance Type 1',
   },
-  { identifier: 'Instance Type 2' },
+  { id: 'Instance Type 2' },
 ];


### PR DESCRIPTION
While the tests are running there are some console errors:

1. 
```    console.error
      Warning: Each child in a list should have a unique "key" prop.
      Check the render method of `InstanceTypesSelect`. See https://reactjs.org/link/warning-keys for more information.

````
reason: the fixtures don't have `id` props
2.
```
 Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one.
```  

reason: `waitFor`  is async and should be wrapped by a promise / async-await