### PR TITLE
Add image prop to wizard

### DIFF
--- a/src/Components/DescriptionListAWS/index.js
+++ b/src/Components/DescriptionListAWS/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {
   DescriptionList,
@@ -11,7 +12,7 @@ import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
 import { useWizardContext } from '../Common/WizardContext';
 
-const DescriptionListAWS = () => {
+const DescriptionListAWS = ({ imageName }) => {
   const [wizardContext] = useWizardContext();
   const { error, data: sources } = useQuery(
     SOURCES_QUERY_KEY,
@@ -24,10 +25,14 @@ const DescriptionListAWS = () => {
   }
 
   const getChosenSourceName = () =>
-    sources.find((source) => source.id === wizardContext.chosenSource).name;
+    sources?.find((source) => source.id === wizardContext.chosenSource).name;
 
   return (
     <DescriptionList isHorizontal>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Image</DescriptionListTerm>
+        <DescriptionListDescription>{imageName}</DescriptionListDescription>
+      </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Account</DescriptionListTerm>
         <DescriptionListDescription>
@@ -56,5 +61,9 @@ const DescriptionListAWS = () => {
       </DescriptionListGroup>
     </DescriptionList>
   );
+};
+
+DescriptionListAWS.propTypes = {
+  imageName: PropTypes.string.isRequired,
 };
 export default DescriptionListAWS;

--- a/src/Components/ExpandableAWS/index.js
+++ b/src/Components/ExpandableAWS/index.js
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
 import DescriptionListAWS from '../DescriptionListAWS';
-export const ExpandableAWS = () => {
+export const ExpandableAWS = ({ imageName }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const onToggle = (isExpanded) => {
     setIsExpanded(isExpanded);
@@ -13,7 +14,11 @@ export const ExpandableAWS = () => {
       isExpanded={isExpanded}
       isIndented
     >
-      <DescriptionListAWS />
+      <DescriptionListAWS imageName={imageName} />
     </ExpandableSection>
   );
+};
+
+ExpandableAWS.propTypes = {
+  imageName: PropTypes.string.isRequired,
 };

--- a/src/Components/Wizard/index.js
+++ b/src/Components/Wizard/index.js
@@ -8,9 +8,9 @@ import APIProvider from '../Common/Query';
 import defaultSteps from './steps';
 import { useDispatch } from 'react-redux';
 
-const ProvisioningWizard = ({ isOpen, onClose, ...props }) => {
+const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
   const [stepIdReached, setStepIdReached] = React.useState(1);
-  const steps = defaultSteps({ stepIdReached });
+  const steps = defaultSteps({ stepIdReached, image });
   const dispatch = useDispatch();
 
   const onNext = ({ id, name }, { prevId, prevName }) => {
@@ -51,8 +51,12 @@ const ProvisioningWizard = ({ isOpen, onClose, ...props }) => {
 };
 
 ProvisioningWizard.propTypes = {
-  isOpen: PropTypes.bool,
+  isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
+  image: PropTypes.shape({
+    name: PropTypes.string,
+    id: PropTypes.string,
+  }).isRequired,
 };
 
 export default ProvisioningWizard;

--- a/src/Components/Wizard/steps/ReviewDetails/index.js
+++ b/src/Components/Wizard/steps/ReviewDetails/index.js
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Stack, StackItem, Title } from '@patternfly/react-core';
 import { ExpandableAWS } from '../../../ExpandableAWS';
 
-const ReviewDetails = () => {
+const ReviewDetails = ({ imageName }) => {
   return (
     <Stack hasGutter>
       <StackItem>
@@ -15,9 +16,13 @@ const ReviewDetails = () => {
         </Title>
       </StackItem>
       <StackItem>
-        <ExpandableAWS />
+        <ExpandableAWS imageName={imageName} />
       </StackItem>
     </Stack>
   );
+};
+
+ReviewDetails.propTypes = {
+  imageName: PropTypes.string.isRequired,
 };
 export default ReviewDetails;

--- a/src/Components/Wizard/steps/index.js
+++ b/src/Components/Wizard/steps/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import AccountCustomizationsAWS from '../steps/AccountCustomizations/aws';
 import ReviewDetails from './ReviewDetails';
 
-const defaultSteps = ({ stepIdReached }) => [
+const defaultSteps = ({ stepIdReached, image: { name } }) => [
   {
     name: 'Account and customization',
     steps: [
@@ -35,7 +35,7 @@ const defaultSteps = ({ stepIdReached }) => [
   {
     name: 'Review details',
     id: 5,
-    component: <ReviewDetails />,
+    component: <ReviewDetails imageName={name} />,
     canJumpTo: stepIdReached >= 5,
     nextButtonText: 'Submit',
   },

--- a/src/Routes/SamplePage/SamplePage.js
+++ b/src/Routes/SamplePage/SamplePage.js
@@ -41,6 +41,7 @@ const SamplePage = () => {
             <ProvisioningWizard
               isOpen={isWizardOpen}
               onClose={() => setWizardModal(false)}
+              image={{ name: 'example-image', id: 'composeID' }}
             />
           </StackItem>
         </Stack>


### PR DESCRIPTION
This adds an `image` prop to the `ProvisioningWizard` component
This prop is an object with a shape of `{ name: string, ami: string }`

The [ami](https://github.com/RedHatInsights/image-builder-frontend/blob/main/src/Components/ImagesTable/ImageLink.js#L29) already exists in the image-builder front application, so it seems redundant to fetch it later in our backend by the image identifier. The image's name prop propagates to the review page, so the user is notified just before the reservation is made.

```js
    <ProvisioningWizard
       isOpen={isWizardOpen}
       onClose={onCloseFn}
       image={{ name: 'example-image', ami: 'ami-0c830793775595d4b' }}
    />
```

- [ ] Testing