### PR TITLE
Correct name in clowder template metadata

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -6,7 +6,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: provisioning-frontend
+      name: provisioning
     spec:
       envName: ${ENV_NAME}
       title: Provisioning


### PR DESCRIPTION
As per other teams examples, this needs to be an app name, not component name.

Thanks @karelhala :)

FYI @mshriver, @jlsherrill