### PR TITLE
Add finish progress step

### DIFF
--- a/src/API/index.js
+++ b/src/API/index.js
@@ -17,3 +17,17 @@ export const fetchInstanceTypesList = async (sourceId) => {
   );
   return data;
 };
+
+export const createAWSReservation = async (params) => {
+  return axios.post(provisioningUrl('reservations/aws'), params);
+};
+
+export const createNewPublicKey = async (params) => {
+  return axios.post(provisioningUrl('pubkeys'), params);
+};
+
+// TODO: filtering a specific reservation status in backend
+export const fetchAWSReservation = async () => {
+  const { data } = await axios.get(provisioningUrl('reservations'));
+  return data;
+};

--- a/src/Components/Wizard/index.js
+++ b/src/Components/Wizard/index.js
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
 import { Wizard } from '@patternfly/react-core';
 import React from 'react';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 import { WizardProvider } from '../Common/WizardContext';
 import APIProvider from '../Common/Query';
 import defaultSteps from './steps';
-import { useDispatch } from 'react-redux';
 
 const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
   const [stepIdReached, setStepIdReached] = React.useState(1);
@@ -19,26 +17,14 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
     image,
     stepValidation,
     setStepValidation,
+    onClose,
   });
-  const dispatch = useDispatch();
 
   const onNext = ({ id, name }, { prevId, prevName }) => {
     console.debug(
       `current id: ${id}, current name: ${name}, previous id: ${prevId}, previous name: ${prevName}`
     );
     setStepIdReached((prevID) => (prevID < id ? id : prevID));
-  };
-
-  const handleAlert = () => {
-    dispatch(
-      addNotification({
-        variant: 'success',
-        title: 'Provisioning has been started',
-        description:
-          'a notification will be trigger after a success or failure',
-      })
-    );
-    onClose();
   };
 
   return (
@@ -52,7 +38,6 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
           isOpen={isOpen}
           onClose={onClose}
           onNext={onNext}
-          onSave={handleAlert}
         />
       </APIProvider>
     </WizardProvider>

--- a/src/Components/Wizard/steps/FinishProgress/index.js
+++ b/src/Components/Wizard/steps/FinishProgress/index.js
@@ -1,0 +1,153 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Title,
+  Progress,
+  Button,
+} from '@patternfly/react-core';
+import { CogsIcon, OkIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
+import { useWizardContext } from '../../../Common/WizardContext';
+import { useMutation } from 'react-query';
+import { createAWSReservation, createNewPublicKey } from '../../../../API';
+import './styles.scss';
+
+const pf_success_color_100 = '#3E8635';
+const pf_danger_color_100 = '#C9190B';
+
+const FinishStep = ({ onClose, imageID }) => {
+  const [
+    {
+      chosenSource,
+      chosenInstanceType,
+      chosenNumOfInstances,
+      sshPublicName,
+      sshPublicKey,
+      chosenSshKeyId,
+    },
+  ] = useWizardContext();
+  const [, setReservationID] = React.useState();
+  const [activeStep, setActiveStep] = React.useState(chosenSshKeyId ? 1 : 0);
+  const stepUp = () => setActiveStep((prevStep) => prevStep++);
+
+  const { mutate: createAWSDeployment, error: awsReservationError } =
+    useMutation(createAWSReservation, {
+      onSuccess: (data) => {
+        stepUp();
+        setReservationID(data.reservation_id);
+        // TODO: start polling for job status
+      },
+    });
+
+  const { mutate: createPublicKey, error: pubkeyError } = useMutation(
+    createNewPublicKey,
+    {
+      onSuccess: (resp) => {
+        createAWSDeployment({
+          source_id: chosenSource,
+          instance_type: chosenInstanceType,
+          amount: chosenNumOfInstances,
+          image_id: imageID,
+          pubkey_id: resp?.data?.id,
+        });
+        stepUp();
+      },
+    }
+  );
+
+  React.useEffect(() => {
+    if (chosenSshKeyId) {
+      createAWSDeployment({
+        source_id: chosenSource,
+        instance_type: chosenInstanceType,
+        amount: chosenNumOfInstances,
+        image_id: imageID,
+        pubkey_id: chosenSshKeyId,
+      });
+    } else {
+      createPublicKey({ name: sshPublicName, body: sshPublicKey });
+    }
+  }, []);
+
+  const steps = [
+    { description: 'Uploading SSH public key', progress: 0 },
+    { description: 'Creating AWS reservation', progress: 20 },
+    {
+      description:
+        'Waiting for AWS, it might take a few minutes, it is safe to close the wizard',
+      progress: 60,
+    },
+    { description: 'Provisioning has been completed', progress: 100 },
+  ];
+
+  const activeProgress = steps[activeStep].progress;
+  const isError = !!awsReservationError || !!pubkeyError;
+
+  const iconGenerator = () => {
+    if (isError) return ErrorCircleOIcon;
+    return activeProgress === 100 ? OkIcon : CogsIcon;
+  };
+
+  const showCloseButton = () => {
+    if (isError) return true;
+    return activeStep >= 2;
+  };
+
+  const iconColor = () => {
+    if (isError) return pf_danger_color_100;
+    if (activeProgress === 100) return pf_success_color_100;
+    return undefined;
+  };
+
+  return (
+    <EmptyState variant="large">
+      <EmptyStateIcon color={iconColor()} icon={iconGenerator()} />
+      <Title headingLevel="h4" size="lg">
+        {activeProgress === 100
+          ? 'Provisioning has been finished successfully'
+          : 'Provisioning in progress'}
+      </Title>
+      <EmptyStateBody>
+        <Progress
+          style={{ width: '500px' }}
+          variant={isError && 'danger'}
+          value={activeProgress}
+          measureLocation="outside"
+        />
+      </EmptyStateBody>
+      <EmptyStateBody>
+        <span>
+          {isError
+            ? `An error has been occurred while ${steps[
+                activeStep
+              ].description.toLowerCase()}`
+            : steps[activeStep].description}
+          <br />
+          <span className="status-error">
+            {awsReservationError?.response?.data?.msg}
+            {pubkeyError?.response?.data?.msg}
+          </span>
+        </span>
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button
+          variant="link"
+          isDisabled={!showCloseButton()}
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+FinishStep.propTypes = {
+  imageID: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default FinishStep;

--- a/src/Components/Wizard/steps/FinishProgress/styles.scss
+++ b/src/Components/Wizard/steps/FinishProgress/styles.scss
@@ -1,0 +1,7 @@
+.status-success {
+  color: var(--pf-global--success-color--100);
+}
+
+.status-error {
+  color: var(--pf-global--danger-color--100);
+}

--- a/src/Components/Wizard/steps/index.js
+++ b/src/Components/Wizard/steps/index.js
@@ -2,12 +2,14 @@ import React from 'react';
 import AccountCustomizationsAWS from '../steps/AccountCustomizations/aws';
 import ReviewDetails from './ReviewDetails';
 import PublicKeys from './Pubkeys';
+import FinishStep from './FinishProgress';
 
 const defaultSteps = ({
   stepIdReached,
-  image: { name },
+  image: { name, id },
   stepValidation,
   setStepValidation,
+  onClose,
 }) => [
   {
     name: 'Account and customization',
@@ -51,6 +53,12 @@ const defaultSteps = ({
     component: <ReviewDetails imageName={name} />,
     canJumpTo: stepIdReached >= 5,
     nextButtonText: 'Submit',
+  },
+  {
+    name: 'Finish Progress',
+    id: 6,
+    component: <FinishStep onClose={onClose} imageID={id} />,
+    isFinishedStep: true,
   },
 ];
 


### PR DESCRIPTION
Depended on #56

### No error
https://user-images.githubusercontent.com/11807069/186199592-29d07436-d04c-4084-9866-0b2ba732c25b.mov

### With error
https://user-images.githubusercontent.com/11807069/186199645-e02cfb48-8400-428e-8c4b-a2c4cebb5ef8.mov




This PR adds a progress screen after submission, developed according to  PF4 design recommendation: https://www.patternfly.org/v4/components/wizard/design-guidelines

- [x] Add progress component
- [x] Trigger public ssh key upload
- [x] Trigger AWS reservation creation
- [x] Render errors
- [ ] Testing
- [ ] Optional: create a polling for reservation status
