### PR TITLE
remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@patternfly/react-core": "4.224.1",
-        "@patternfly/react-table": "4.93.1",
         "@redhat-cloud-services/frontend-components": "^3.9.3",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.6",
@@ -2727,6 +2726,7 @@
       "version": "4.93.1",
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
       "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+      "peer": true,
       "dependencies": {
         "@patternfly/react-core": "^4.224.1",
         "@patternfly/react-icons": "^4.75.1",
@@ -2743,7 +2743,8 @@
     "node_modules/@patternfly/react-table/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
     },
     "node_modules/@patternfly/react-tokens": {
       "version": "4.76.1",
@@ -19301,6 +19302,7 @@
       "version": "4.93.1",
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
       "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+      "peer": true,
       "requires": {
         "@patternfly/react-core": "^4.224.1",
         "@patternfly/react-icons": "^4.75.1",
@@ -19313,7 +19315,8 @@
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@patternfly/react-core": "4.224.1",
-    "@patternfly/react-table": "4.93.1",
     "@redhat-cloud-services/frontend-components": "^3.9.3",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.6",


### PR DESCRIPTION
This PR removes `@patternfly/react-table`
I wonder if we want also to remove redux if we are not going to use toast notifications 