### PR TITLE
Add region to createAWSDeployment

### DIFF
--- a/src/Components/DescriptionListAWS/index.js
+++ b/src/Components/DescriptionListAWS/index.js
@@ -41,7 +41,9 @@ const DescriptionListAWS = ({ imageName }) => {
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Region</DescriptionListTerm>
-        <DescriptionListDescription>US - east</DescriptionListDescription>
+        <DescriptionListDescription>
+          {wizardContext.chosenRegion}
+        </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Instance type</DescriptionListTerm>

--- a/src/Components/RegionsSelect/index.js
+++ b/src/Components/RegionsSelect/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { FormSelect, FormSelectOption } from '@patternfly/react-core';
-
+import { useWizardContext } from '../Common/WizardContext';
 export const RegionsSelect = () => {
+  const [wizardContext] = useWizardContext();
   return (
     <FormSelect isDisabled aria-label="Select region" value="">
       <FormSelectOption
-        label="US - east"
+        label={wizardContext.chosenRegion}
         key="placeholder"
         isPlaceholder
         value=""

--- a/src/Components/Wizard/steps/FinishProgress/index.js
+++ b/src/Components/Wizard/steps/FinishProgress/index.js
@@ -35,6 +35,7 @@ const FinishStep = ({ onClose, imageID }) => {
       chosenSource,
       chosenInstanceType,
       chosenNumOfInstances,
+      chosenRegion,
       sshPublicName,
       sshPublicKey,
       chosenSshKeyId,
@@ -63,6 +64,7 @@ const FinishStep = ({ onClose, imageID }) => {
           instance_type: chosenInstanceType,
           amount: chosenNumOfInstances,
           image_id: imageID,
+          region: chosenRegion,
           pubkey_id: resp?.data?.id,
         });
         stepUp();
@@ -79,6 +81,7 @@ const FinishStep = ({ onClose, imageID }) => {
         instance_type: chosenInstanceType,
         amount: chosenNumOfInstances,
         image_id: imageID,
+        region: chosenRegion,
         pubkey_id: chosenSshKeyId,
       });
     }


### PR DESCRIPTION
This is a temporary fix!
- Removing the hard-coded "US- east" 
- Using the default value we have in the wizardContext. 
After getting all the information we need about regions from image builder we would list only the regions the customer had chosen in image builder step. 
