### PR TITLE
Swith to new instance types endpoint

### DIFF
--- a/src/API/index.js
+++ b/src/API/index.js
@@ -11,9 +11,9 @@ export const fetchPubkeysList = async () => {
   return data;
 };
 
-export const fetchInstanceTypesList = async (sourceId, region) => {
+export const fetchInstanceTypesList = async (region) => {
   const { data } = await axios.get(
-    provisioningUrl(`sources/${sourceId}/instance_types?region=${region}`)
+    provisioningUrl(`instance_types/aws?region=${region}`)
   );
   return data;
 };

--- a/src/API/queryKeys.js
+++ b/src/API/queryKeys.js
@@ -1,7 +1,3 @@
 export const SOURCES_QUERY_KEY = 'sources';
 export const PUBKEYS_QUERY_KEY = 'pubkeys';
-export const instanceTypesQueryKeys = (source, region) => [
-  'instanceTypes',
-  source,
-  region,
-];
+export const instanceTypesQueryKeys = (region) => ['instanceTypes', region];

--- a/src/Components/InstanceTypesSelect/index.js
+++ b/src/Components/InstanceTypesSelect/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Spinner, Select, SelectOption } from '@patternfly/react-core';
+import { Alert, Spinner, Select, SelectOption } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
 import { instanceTypesQueryKeys } from '../../API/queryKeys';
 import { fetchInstanceTypesList } from '../../API';
@@ -18,17 +18,8 @@ const InstanceTypesSelect = ({ setValidation }) => {
     isLoading,
     error,
     data: instanceTypes,
-  } = useQuery(
-    instanceTypesQueryKeys(
-      wizardContext.chosenSource,
-      wizardContext.chosenRegion
-    ),
-    () =>
-      fetchInstanceTypesList(
-        wizardContext.chosenSource,
-        wizardContext.chosenRegion
-      ),
-    { enabled: !!wizardContext.chosenSource }
+  } = useQuery(instanceTypesQueryKeys(wizardContext.chosenRegion), () =>
+    fetchInstanceTypesList(wizardContext.chosenRegion)
   );
 
   if (!wizardContext.chosenSource || wizardContext.chosenSource === '') {
@@ -104,8 +95,21 @@ const InstanceTypesSelect = ({ setValidation }) => {
   };
 
   if (error) {
-    // TODO: error handling, notifications
-    console.log('Failed to fetch instance types list');
+    console.warn('Failed to fetch instance types list');
+    return (
+      <>
+        <Alert
+          variant="warning"
+          isInline
+          title="There are problems fetching instance types"
+        />
+        <Select
+          isDisabled
+          placeholderText="No instance types found"
+          aria-label="Select instance type"
+        />
+      </>
+    );
   }
   if (isLoading) {
     return (

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -11,10 +11,7 @@ export const handlers = [
   rest.get(provisioningUrl('pubkeys'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(pubkeysList));
   }),
-  rest.get(
-    provisioningUrl('sources/:sourceID/instance_types'),
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(instanceTypeList));
-    }
-  ),
+  rest.get(provisioningUrl('instance_types/aws'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(instanceTypeList));
+  }),
 ];


### PR DESCRIPTION
Uses the new static endpoint to load instance types.

Depends on https://github.com/RHEnVision/provisioning-backend/pull/245