### PR TITLE
Review step ux

### DIFF
--- a/src/Components/ConfirmModal/index.js
+++ b/src/Components/ConfirmModal/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+
+const ConfirmModal = ({ isOpen, onConfirm, onCancel }) => (
+  <Modal
+    ouiaId="app-confirm-modal"
+    id="app-confirm-modal"
+    aria-label="confirm cancel of launch modal"
+    variant={ModalVariant.small}
+    title="Exit instance launching?"
+    isOpen={isOpen}
+    onClose={onCancel}
+    actions={[
+      <Button
+        key="exit"
+        variant="primary"
+        onClick={onConfirm}
+        ouiaId="btn-exit-confirm"
+      >
+        Exit
+      </Button>,
+      <Button key="stay" variant="link" onClick={onCancel}>
+        Stay
+      </Button>,
+    ]}
+    titleIconVariant="warning"
+  >
+    All inputs will be discarded.
+  </Modal>
+);
+
+ConfirmModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ConfirmModal;

--- a/src/Components/ProvisioningWizard/index.js
+++ b/src/Components/ProvisioningWizard/index.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { WizardProvider } from '../Common/WizardContext';
 import APIProvider from '../Common/Query';
 import defaultSteps from './steps';
+import ConfirmModal from '../ConfirmModal';
 
 const DEFAULT_STEP_VALIDATION = {
   sshStep: false,
@@ -16,11 +17,21 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
   const [stepValidation, setStepValidation] = React.useState(
     DEFAULT_STEP_VALIDATION
   );
+  const [isConfirming, setConfirming] = React.useState(false);
 
   const onCustomClose = () => {
+    setConfirming(false);
     setStepIdReached(1);
     setStepValidation(DEFAULT_STEP_VALIDATION);
     onClose();
+  };
+
+  const onWizardClose = () => {
+    if (stepIdReached >= 5) {
+      setConfirming(true);
+    } else {
+      onCustomClose();
+    }
   };
 
   const steps = defaultSteps({
@@ -47,8 +58,13 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
           description={`Provision image ${image.name}`}
           steps={steps}
           isOpen
-          onClose={onCustomClose}
+          onClose={onWizardClose}
           onNext={onNext}
+        />
+        <ConfirmModal
+          isOpen={isConfirming}
+          onConfirm={onCustomClose}
+          onCancel={() => setConfirming(false)}
         />
       </APIProvider>
     </WizardProvider>

--- a/src/Components/ProvisioningWizard/steps/ReviewDetails/index.js
+++ b/src/Components/ProvisioningWizard/steps/ReviewDetails/index.js
@@ -6,9 +6,9 @@ import { ExpandableAWS } from '../../../ExpandableAWS';
 const ReviewDetails = ({ imageName }) => {
   return (
     <div className="pf-c-form">
-      <Title headingLevel="h1">Review Details</Title>
+      <Title headingLevel="h1">Review details</Title>
       <Text>
-        Review the information below and click <b>Finish</b> to complete
+        Review the information below and click <b>Launch</b> to complete
         provisioning.
       </Text>
 

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -47,7 +47,7 @@ const defaultSteps = ({
     id: 5,
     component: <ReviewDetails imageName={name} />,
     canJumpTo: stepIdReached >= 3,
-    nextButtonText: 'Submit',
+    nextButtonText: 'Launch',
   },
   {
     name: 'Finish Progress',

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -39,14 +39,14 @@ const defaultSteps = ({
         }
       />
     ),
-    canJumpTo: stepIdReached >= 2,
+    canJumpTo: stepIdReached >= 4,
     enableNext: stepValidation.sshStep,
   },
   {
     name: 'Review details',
     id: 5,
     component: <ReviewDetails imageName={name} />,
-    canJumpTo: stepIdReached >= 3,
+    canJumpTo: stepIdReached >= 5,
     nextButtonText: 'Launch',
   },
   {


### PR DESCRIPTION
Unify finish button text and use "Launch" label

Add exit confirmation, when user has reached the review step and thus 
filled a lot of data (previous steps will still allow canceling without confirm).

![exit_dialog](https://user-images.githubusercontent.com/2884324/194060082-920a7304-afa4-42fc-9611-93fa49ef3b13.png)
