### PR TITLE
enable running front dev with staged api backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log*
 
 .DS_Store
 coverage
+.cache/*

--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -1,0 +1,7 @@
+const LOCAL_API_PORT = 8000;
+
+module.exports = {
+  routes: {
+    '/api/provisioning': { host: `http://localhost:${LOCAL_API_PORT}` },
+  },
+};

--- a/fec.config.js
+++ b/fec.config.js
@@ -14,9 +14,7 @@ module.exports = {
    * Add additional webpack plugins
    */
   plugins: [],
-  routes: {
-    '/api/provisioning': { host: `http://localhost:8000` }
-  },
+  routesPath: process.env.ROUTES_PATH && resolve(process.env.ROUTES_PATH),
   moduleFederation: {
     exposes: {
       './RootApp': resolve(__dirname, './src/AppEntry'),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "patch:hosts": "fec patch-etc-hosts",
-    "start": "fec dev",
+    "start": "PROXY=true ROUTES_PATH=config/routes.config.js fec dev",
+    "start:stage": "PROXY=true fec dev",
     "start:federated": "fec static",
     "test": "jest",
     "verify": "npm-run-all build lint test"


### PR DESCRIPTION
This PR extracts the local routes (i.e local API server) from the `fec.config` and allows running frontend with no local provisioning API (communicates directly to the stage)

``` bash
# runs the provisioning-frontend without local provisioning API
npm run start:stage 
```


```bash
# runs the provisioning-frontend including webpack proxy for communicating with the local provisioning API
npm run start
```
