### PR TITLE
chore: add changelog and generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+<a name="0.12.0"></a>
+## [0.12.0](https://github.com/RHEnVision/provisioning-backend/compare/0.11.0...0.12.0) (2022-11-27)
+
+### Bug Fixes
+- **HMSPROV-364:** popover body style ([63073d4](https://github.com/RHEnVision/provisioning-backend/commit/63073d4842e5fa8d55a08ef28922fc606a2b609e))
+- **text:** Improve textation of review description ([dde2273](https://github.com/RHEnVision/provisioning-backend/commit/dde22738e6e71d4241dcd2e4b7bd42e5ed790c62))
+
+### Features
+- add reservation id as hidden field ([a419d49](https://github.com/RHEnVision/provisioning-backend/commit/a419d49f5b7569db5da738999ec4b99cd46657d5)), related to [HMSPROV-359](https://issues.redhat.com/browse/HMSPROV-359)
+
+
+<a name="0.11.0"></a>
+## [0.11.0](https://github.com/RHEnVision/provisioning-backend/compare/7029e78f6ba13aef3591c2685700253ba3eb4480...0.11.0) (2022-11-14)
+
+### Bug Fixes
+- **pubkeys:** Component refresh does not move cursor ([34b88b7](https://github.com/RHEnVision/provisioning-backend/commit/34b88b7844ed12e49d13a0ccb84de4ab56800b19)), related to [HMSPROV-270](https://issues.redhat.com/browse/HMSPROV-270)
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+export PROXY = true
+
+.PHONY: run
+run:
+	npm run start
+
+.PHONY: install
+install:
+	npm install
+
+.PHONY: generate-changelog
+generate-changelog:
+	scripts/changelog.py

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import os.path
+from pathlib import Path
+from typing import List, Optional
+
+from git_changelog import templates
+from git_changelog.build import Changelog
+from git_changelog.providers import GitHub, RefDef, RefRe
+
+JIRA_URL = "https://issues.redhat.com"
+JIRA_PROJECT = "HMSPROV"
+JIRA_ISSUE_SYMBOL = "HMSPROV-"
+
+GitHub.REF["issues"] = RefDef(
+                           regex=re.compile(RefRe.BB + RefRe.ID.format(symbol=JIRA_ISSUE_SYMBOL), re.I),
+                           url_string=(JIRA_URL + "/browse/" + JIRA_PROJECT + "-{ref}"),
+                       )
+
+class SingleCommitLog(Changelog):
+  def get_log(self) -> str:
+    """Get the `git log` output limited to single commit.
+
+    Returns:
+        The output of the `git log` command, with a particular format.
+    """
+    return self.run_git("log", "-1", "--date=unix", "--format=" + self.FORMAT)
+
+def main(args: Optional[List[str]] = None) -> int:
+  provider = GitHub("RHEnVision", "provisioning-backend", url="https://github.com")
+  path = Path(os.path.abspath(__file__))
+  repo = path.parent.parent
+  changelog = Changelog(repo, provider=provider, style="angular")
+  template = templates.get_template("angular")
+  rendered = template.render(changelog=changelog)
+
+  # sys.stdout.write(rendered)
+  with open(repo.joinpath("CHANGELOG.md"), "w") as stream:
+    stream.write(rendered)
+
+  return 0
+
+def check_commit(length_limit = 70) -> int:
+  provider = GitHub("RHEnVision", "provisioning-backend", url="https://github.com")
+  path = Path(os.path.abspath(__file__))
+  repo = path.parent.parent
+  changelog = SingleCommitLog(repo, provider=provider, style="angular")
+
+  commit = changelog.commits[0]
+  if len(commit.subject) > length_limit:
+    sys.stderr.write("ERROR: Commit message length too long (limit is " + 70 + "): " + commit.subject)
+    return 1
+
+  if commit.style["type"] == "":
+    sys.stderr.write("ERROR: Commit message must have a type 'type: subject': " + commit.subject)
+    return 2
+
+  if commit.style["type"] in ["Features", "Bug Fixes"]:
+    if commit.style["scope"] is not None and JIRA_ISSUE_SYMBOL not in commit.style["scope"]:
+      sys.stderr.write("ERROR: Scope for Feature and Bug fix needs to be Jira issue in format '"+JIRA_ISSUE_SYMBOL+"XXX': " + commit.style["scope"])
+      return 2
+
+    if "issues" not in commit.text_refs or len(commit.text_refs["issues"]) == 0:
+      sys.stderr.write("ERROR: Feature and bug fix must have a Jira issue linked")
+      sys.stderr.write("ERROR: You can link the issue either in subject as 'feat("+JIRA_ISSUE_SYMBOL+"XXX): subject': " + commit.subject)
+      sys.stderr.write("ERROR: or anywhere in the body preferably as 'Fixes: "+JIRA_ISSUE_SYMBOL+"XXX' or Refs: "+JIRA_ISSUE_SYMBOL+"XXX")
+      return 3
+
+  return 0
+
+if __name__ == '__main__':
+  if len(sys.argv) > 1 and sys.argv[1] == 'commit-check':
+    sys.exit(check_commit())
+  else:
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
I propose to start tagging "releases" in the same cadence as we do for backend - every sprint. So I created 0.11 (roughly to the sprint start) and 0.12 for today (demo time). And copied the changelog generation script and generated changelog. I think a copy of the script will do, we should not change it too often.

If this is approved and merged, I will also push the tags.