### PR TITLE
fix(HMSPROV-378) - use userEvent over fireEvent

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,7 +43,7 @@ In order to access `WizardContext` and `react-query` provider, the `render` func
 You can import all `testing-library` related functions from `mocks/utils`
 
 ```js
-import { render, fireEvent, screen } from '../../mocks/utils';
+import { render, screen } from '../../mocks/utils';
 
   test('Loading state', async () => {
     // the component will be rended with wizard context and react-query provider

--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import InstanceTypesSelect from '.';
 import { instanceTypeList } from '../../mocks/fixtures/instanceTypes.fixtures';
-import { render, fireEvent, screen } from '../../mocks/utils';
+import { render, screen } from '../../mocks/utils';
 
 describe('InstanceTypesSelect', () => {
   test('populate instance types select', async () => {
@@ -13,13 +14,13 @@ describe('InstanceTypesSelect', () => {
   describe('search', () => {
     test('filter items', async () => {
       const dropdown = await mountSelectAndClick();
-      fireEvent.change(dropdown, { target: { value: 'm5' } });
+      await userEvent.type(dropdown, 'm5');
       const items = await screen.findAllByLabelText('Instance Type item');
       expect(items).toHaveLength(1);
     });
     test('handles weird input', async () => {
       const dropdown = await mountSelectAndClick();
-      fireEvent.change(dropdown, { target: { value: '```' } });
+      await userEvent.type(dropdown, '```');
       const items = await screen.queryAllByLabelText('Instance Type item');
       expect(items).toHaveLength(0);
     });
@@ -29,6 +30,6 @@ describe('InstanceTypesSelect', () => {
 const mountSelectAndClick = async () => {
   render(<InstanceTypesSelect architecture="x86_64" setValidation={jest.fn()} />);
   const selectDropdown = await screen.findByPlaceholderText('Select instance type');
-  fireEvent.click(selectDropdown);
+  await userEvent.click(selectDropdown);
   return selectDropdown;
 };

--- a/src/Components/ProvisioningWizard/steps/Pubkeys/Pubkeys.test.js
+++ b/src/Components/ProvisioningWizard/steps/Pubkeys/Pubkeys.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import Pubkeys from '.';
-import { render, fireEvent, screen } from '../../../../mocks/utils';
+
+import { render, screen } from '../../../../mocks/utils';
 
 describe('Pubkeys', () => {
   describe('with data', () => {
@@ -9,7 +11,7 @@ describe('Pubkeys', () => {
       const existingRadio = screen.getByTestId('existing-pubkey-radio');
       expect(existingRadio).toBeChecked();
       const select = await screen.findByText('Select public key...');
-      fireEvent.click(select);
+      await userEvent.click(select);
       const items = screen.getAllByLabelText(/^Public key/);
       expect(items).toHaveLength(2);
     });
@@ -24,13 +26,13 @@ describe('Pubkeys', () => {
       // mark step as invalid by default
       expect(currentlyValid).toEqual(false);
 
-      fireEvent.click(select);
-      fireEvent.click(screen.getByLabelText('Public key lzap-ed25519-2021'));
+      await userEvent.click(select);
+      await userEvent.click(screen.getByLabelText('Public key lzap-ed25519-2021'));
       // mark step as valid after selection
       expect(currentlyValid).toEqual(true);
 
-      fireEvent.click(screen.getByTestId('upload-pubkey-radio'));
-      fireEvent.click(screen.getByTestId('existing-pubkey-radio'));
+      await userEvent.click(screen.getByTestId('upload-pubkey-radio'));
+      await userEvent.click(screen.getByTestId('existing-pubkey-radio'));
 
       // step is valid after selection of uploding key and returning
       expect(screen.getByText('lzap-ed25519-2021'));

--- a/src/Components/SourcesSelect/SourcesSelect.test.js
+++ b/src/Components/SourcesSelect/SourcesSelect.test.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import SourcesSelect from '.';
+import userEvent from '@testing-library/user-event';
 import { sourcesList } from '../../mocks/fixtures/sources.fixtures';
-import { render, fireEvent, screen } from '../../mocks/utils';
+import { render, screen } from '../../mocks/utils';
 
 describe('SourcesSelect', () => {
   test('preselects the chosen source', async () => {
     render(<SourcesSelect setValidation={jest.fn()} />);
     // wizard context mock is `{chosenSource: 1}`
     const selectDropdown = await screen.findByText('Source 1');
-    fireEvent.click(selectDropdown);
+    await userEvent.click(selectDropdown);
+
     const items = await screen.findAllByLabelText('Source account');
     expect(items).toHaveLength(sourcesList.length);
   });


### PR DESCRIPTION
`userEvent` is made for mimicking  real user interactions with the screen, react testing library recommends using it  for testing user interactions (i.e typing, clicking, mouse focus)  over the lower api `fireEvent`