### PR TITLE
feat(HMSPROV-419): add a timeout session for reservation polling

### DIFF
--- a/src/Components/Common/Hooks/useTimeout.js
+++ b/src/Components/Common/Hooks/useTimeout.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const useTimeout = (callback, delay) => {
+  const timeoutRef = React.useRef(null);
+  const savedCallback = React.useRef(callback);
+  React.useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+  React.useEffect(() => {
+    const tick = () => savedCallback.current();
+    if (typeof delay === 'number') {
+      timeoutRef.current = window.setTimeout(tick, delay);
+      return () => window.clearTimeout(timeoutRef.current);
+    }
+  }, [delay]);
+  return timeoutRef;
+};
+
+export default useTimeout;

--- a/src/Components/ProvisioningWizard/steps/FinishProgress/FinishProgress.test.js
+++ b/src/Components/ProvisioningWizard/steps/FinishProgress/FinishProgress.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import FinishProgress from '.';
+import { provisioningUrl } from '../../../../API/helpers';
+import { errorReservation } from '../../../../mocks/fixtures/reservation.fixtures';
+import { render, screen } from '../../../../mocks/utils';
+
+describe('FinishProgress', () => {
+  test('progress ends successfully', async () => {
+    mountProgressBar();
+    const progressCompleted = await screen.findByText(/Launch is completed/i);
+    expect(progressCompleted).toBeDefined();
+  });
+
+  test('progress ends with a failure', async () => {
+    const { server, rest } = window.msw;
+    server.use(
+      rest.get(provisioningUrl(`reservations/:id`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(errorReservation));
+      })
+    );
+    mountProgressBar();
+    const errorMessage = await screen.findByText(errorReservation.error);
+    expect(errorMessage).toBeDefined();
+  });
+});
+
+const mountProgressBar = () => {
+  const setLaunchSuccessFunction = jest.fn();
+  const imageID = 'image-id';
+  render(<FinishProgress imageID={imageID} setLaunchSuccess={setLaunchSuccessFunction} />);
+};

--- a/src/mocks/fixtures/reservation.fixtures.js
+++ b/src/mocks/fixtures/reservation.fixtures.js
@@ -1,0 +1,27 @@
+export const reservation = {
+  id: 26,
+  provider: 2,
+  created_at: '2023-01-11T22:44:30.859166Z',
+  steps: 2,
+  step_titles: ['Upload public key', 'Launch instance(s)'],
+  step: 1,
+  status: 'Launching instance(s)',
+  error: null,
+  finished_at: '2023-01-11T22:44:33.495925Z',
+  success: null,
+};
+
+export const successfulReservation = {
+  ...reservation,
+  success: true,
+};
+
+export const errorReservation = {
+  ...reservation,
+  error: 'Some error',
+  success: false,
+};
+
+export const createdAWSReservation = {
+  reservation_id: 26,
+};

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -3,6 +3,7 @@ import { provisioningUrl } from '../API/helpers';
 import { instanceTypeList } from './fixtures/instanceTypes.fixtures';
 import { sourcesList } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
+import { createdAWSReservation, successfulReservation } from './fixtures/reservation.fixtures';
 
 export const handlers = [
   rest.get(provisioningUrl('sources'), (req, res, ctx) => {
@@ -13,5 +14,14 @@ export const handlers = [
   }),
   rest.get(provisioningUrl('instance_types/aws'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(instanceTypeList));
+  }),
+  rest.post(provisioningUrl('pubkeys'), (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+  rest.post(provisioningUrl('reservations/aws'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(createdAWSReservation));
+  }),
+  rest.get(provisioningUrl('reservations/:id'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(successfulReservation));
   }),
 ];


### PR DESCRIPTION
This PR adds a timeout for the reservation polling, to prevent endless progress (network issues, uncaught errors)
In addition, this also stops the polling interval if the reservation ends successfully or with an error.
