### PR TITLE
feat(HMSPROV-419): add a timeout session for reservation polling 

### DIFF
--- a/src/Components/Common/Hooks/useInterval.js
+++ b/src/Components/Common/Hooks/useInterval.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const intervalGenerator = function* (intervalList) {
+  for (const interval of intervalList) yield interval;
+};
+
+const useInterval = (list) => {
+  const generatorRef = React.useRef(null);
+  const savedList = React.useRef(list);
+  const [currentInterval, setCurrentInterval] = React.useState();
+
+  React.useEffect(() => {
+    generatorRef.current = intervalGenerator(savedList.current);
+  }, []);
+
+  const nextInterval = () => {
+    const nextValue = generatorRef.current.next().value;
+    setCurrentInterval(nextValue);
+    if (nextValue === undefined) return false;
+    return nextValue;
+  };
+  return { nextInterval, currentInterval };
+};
+
+export default useInterval;

--- a/src/Components/ProvisioningWizard/steps/FinishProgress/FinishProgress.test.js
+++ b/src/Components/ProvisioningWizard/steps/FinishProgress/FinishProgress.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import FinishProgress from '.';
+import { provisioningUrl } from '../../../../API/helpers';
+import { errorReservation, reservation } from '../../../../mocks/fixtures/reservation.fixtures';
+import { render, screen } from '../../../../mocks/utils';
+import * as constants from './constants';
+
+describe('FinishProgress', () => {
+  test('progress ends successfully', async () => {
+    mountProgressBar();
+    const progressCompleted = await screen.findByText(/Launch is completed/i);
+    expect(progressCompleted).toBeDefined();
+  });
+
+  test('progress ends with a failure', async () => {
+    const { server, rest } = window.msw;
+    server.use(
+      rest.get(provisioningUrl(`reservations/:id`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(errorReservation));
+      })
+    );
+    mountProgressBar();
+    const errorMessage = await screen.findByText(errorReservation.error, { exact: false });
+    expect(errorMessage).toBeDefined();
+  });
+
+  test('show session timed out correctly', async () => {
+    const { server, rest } = window.msw;
+    server.use(
+      rest.get(provisioningUrl(`reservations/:id`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(reservation));
+      })
+    );
+    // eslint-disable-next-line
+    constants.POLLING_BACKOFF_INTERVAL = [false];
+    mountProgressBar();
+    const timeoutMessage = await screen.findByText('Session timed out', { exact: false });
+    expect(timeoutMessage).toBeDefined();
+  });
+});
+
+const mountProgressBar = () => {
+  const setLaunchSuccessFunction = jest.fn();
+  const imageID = 'image-id';
+  render(<FinishProgress imageID={imageID} setLaunchSuccess={setLaunchSuccessFunction} />);
+};

--- a/src/Components/ProvisioningWizard/steps/FinishProgress/constants.js
+++ b/src/Components/ProvisioningWizard/steps/FinishProgress/constants.js
@@ -1,0 +1,15 @@
+export const PF_SUCCESS_100 = '#3E8635';
+export const PF_DANGER_100 = '#C9190B';
+
+export const AWS_STEPS = [
+  { description: 'Uploading SSH public key', progress: 0 },
+  { description: 'Creating AWS reservation', progress: 20 },
+  {
+    description: 'Waiting for AWS',
+    progress: 40,
+  },
+  { description: 'Launch is completed', progress: 100 },
+];
+export const POLLING_BACKOFF_INTERVAL = [
+  500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 3000, 4000, 5000, 10000, 15000, 20000, 25000, 30000,
+];

--- a/src/mocks/fixtures/reservation.fixtures.js
+++ b/src/mocks/fixtures/reservation.fixtures.js
@@ -1,0 +1,27 @@
+export const reservation = {
+  id: 26,
+  provider: 2,
+  created_at: '2023-01-11T22:44:30.859166Z',
+  steps: 2,
+  step_titles: ['Upload public key', 'Launch instance(s)'],
+  step: 1,
+  status: 'Launching instance(s)',
+  error: null,
+  finished_at: '2023-01-11T22:44:33.495925Z',
+  success: null,
+};
+
+export const successfulReservation = {
+  ...reservation,
+  success: true,
+};
+
+export const errorReservation = {
+  ...reservation,
+  error: 'Some error',
+  success: false,
+};
+
+export const createdAWSReservation = {
+  reservation_id: 26,
+};

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -4,6 +4,7 @@ import { instanceTypeList } from './fixtures/instanceTypes.fixtures';
 import { sourcesList } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
 import { clonedImages, parentImage } from './fixtures/image.fixtures';
+import { createdAWSReservation, successfulReservation } from './fixtures/reservation.fixtures';
 
 export const handlers = [
   rest.get(provisioningUrl('sources'), (req, res, ctx) => {
@@ -17,5 +18,14 @@ export const handlers = [
   }),
   rest.get(imageBuilderURL(`composes/${parentImage.id}/clones`), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(clonedImages));
+  }),
+  rest.post(provisioningUrl('pubkeys'), (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+  rest.post(provisioningUrl('reservations/aws'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(createdAWSReservation));
+  }),
+  rest.get(provisioningUrl('reservations/:id'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(successfulReservation));
   }),
 ];


### PR DESCRIPTION
This demonstrates another implementation for a timeout session with no use of additional timers. 
In addition, this PR reduces the number of round trips to the server, due to an interval that increased (not linear) for each try. 