### PR TITLE
fix(HMSPROV-406): filter instance types with substring

### DIFF
--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -24,6 +24,12 @@ describe('InstanceTypesSelect', () => {
       const items = await screen.queryAllByLabelText('Instance Type item');
       expect(items).toHaveLength(0);
     });
+    test('filter with a substring', async () => {
+      const dropdown = await mountSelectAndClick();
+      await userEvent.type(dropdown, 'micro');
+      const items = await screen.findAllByLabelText('Instance Type item');
+      expect(items).toHaveLength(1);
+    });
   });
 });
 

--- a/src/Components/InstanceTypesSelect/index.js
+++ b/src/Components/InstanceTypesSelect/index.js
@@ -66,7 +66,7 @@ const InstanceTypesSelect = ({ setValidation, architecture }) => {
     if (prevSearch !== search) {
       setNumOptions(OPTIONS_PER_SCREEN);
       setPrevSearch(search);
-      setFilteredTypes(instanceTypes.filter((i) => i.name.search(search) === 0));
+      setFilteredTypes(instanceTypes.filter((i) => i.name.includes(search)));
     }
   };
 


### PR DESCRIPTION
This PR allows filtering instance's types with any substring within the type, i.e -  for searching  `micro`, I'll get all the micro types.