### PR TITLE
fix: move to useChrome hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,27 +7,20 @@ import { getRegistry } from '@redhat-cloud-services/frontend-components-utilitie
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import pckg from '../package.json';
 
 const App = (props) => {
   const history = useHistory();
-  const chrome = useChrome();
+  const { on: onChromeEvent } = useChrome();
 
   useEffect(() => {
-    let unregister;
-    if (chrome) {
-      const registry = getRegistry();
-      registry.register({ notifications: notificationsReducer });
-      const { identifyApp, on: onChromeEvent } = chrome.init();
+    const registry = getRegistry();
+    const unregister = onChromeEvent('APP_NAVIGATION', (event) => history.push(`/${event.navId}`));
+    registry.register({ notifications: notificationsReducer });
 
-      // You can use directly the name of your app
-      identifyApp(pckg.insights.appname);
-      unregister = onChromeEvent('APP_NAVIGATION', (event) => history.push(`/${event.navId}`));
-    }
     return () => {
-      unregister();
+      unregister?.();
     };
-  }, [chrome]);
+  }, []);
 
   return (
     <Fragment>


### PR DESCRIPTION
chrome.init has been deperecated in new release of frontend-utilities

Fixes HMSPROV-430