### PR TITLE
fix(HMS-1195): fix ssh page after edit

### DIFF
--- a/src/Components/ProvisioningWizard/steps/Pubkeys/NewKeyForm.js
+++ b/src/Components/ProvisioningWizard/steps/Pubkeys/NewKeyForm.js
@@ -5,16 +5,20 @@ import { useWizardContext } from '../../../Common/WizardContext';
 
 // This is a simple regex format for public ssh key
 const PUBLIC_KEY_FORMAT = '^(ssh|ecdsa)';
+const validatePublicKey = (ssh) => {
+  const regex = new RegExp(PUBLIC_KEY_FORMAT);
+  return regex.test(ssh);
+};
 
 const NewSSHKeyForm = ({ setStepValidated }) => {
-  const [wizardContext, setWizardContext] = useWizardContext();
+  const [{ sshPublicName, sshPublicKey }, setWizardContext] = useWizardContext();
   const [isLoading, setIsLoading] = React.useState();
   const [validations, setValidation] = React.useState({
-    sshKeyBody: 'default',
-    sshKeyName: 'default',
+    sshKeyBody: validatePublicKey(sshPublicKey) ? 'success' : 'default',
+    sshKeyName: sshPublicName ? 'success' : 'default',
   });
-  const [keyName, setName] = React.useState(wizardContext.sshPublicName);
-  const [publicKey, setPublicKey] = React.useState(wizardContext.sshPublicKey);
+  const [keyName, setName] = React.useState(sshPublicName);
+  const [publicKey, setPublicKey] = React.useState(sshPublicKey);
 
   React.useEffect(() => {
     // This effect checks if the entire step is validated
@@ -91,10 +95,6 @@ const NewSSHKeyForm = ({ setStepValidated }) => {
     updateValidation('sshKeyBody', 'error');
   };
 
-  const validatePublicKey = (ssh) => {
-    const regex = new RegExp(PUBLIC_KEY_FORMAT);
-    return regex.test(ssh);
-  };
   return (
     <FormGroup isStack>
       <FormGroup validated={validations.sshKeyName} helperTextInvalid="Name is required" label="Name" isRequired fieldId="ssh-name">

--- a/src/Components/ProvisioningWizard/steps/Pubkeys/Pubkeys.test.js
+++ b/src/Components/ProvisioningWizard/steps/Pubkeys/Pubkeys.test.js
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import Pubkeys from '.';
 
 import { render, screen } from '../../../../mocks/utils';
+import { provisioningUrl } from '../../../../API/helpers';
 
 describe('Pubkeys', () => {
   describe('with data', () => {
@@ -14,6 +15,18 @@ describe('Pubkeys', () => {
       await userEvent.click(select);
       const items = screen.getAllByLabelText(/^Public key/);
       expect(items).toHaveLength(2);
+    });
+
+    test('select is disabled when error', async () => {
+      const { server, rest } = window.msw;
+      server.use(
+        rest.get(provisioningUrl('pubkeys'), (req, res, ctx) => {
+          return res(ctx.status(200), ctx.json([]));
+        })
+      );
+      render(<Pubkeys setStepValidated={jest.fn()} />);
+      const existingRadio = await screen.findByTestId('existing-pubkey-radio');
+      expect(existingRadio).toBeDisabled();
     });
 
     test('validate selection and keep key selection', async () => {

--- a/src/Components/ProvisioningWizard/steps/Pubkeys/index.js
+++ b/src/Components/ProvisioningWizard/steps/Pubkeys/index.js
@@ -13,7 +13,7 @@ const NEW_KEY_OPTION = 'newKey';
 
 const PublicKeys = ({ setStepValidated }) => {
   const [wizardContext, setWizardContext] = useWizardContext();
-  const { isLoading, isError, data: pubkeys } = useQuery(PUBKEYS_QUERY_KEY, fetchPubkeysList);
+  const { isError, data: pubkeys } = useQuery(PUBKEYS_QUERY_KEY, fetchPubkeysList);
   const [isSelectDisabled, disableSelect] = React.useState(false);
 
   const switchTo = (optionKey) => {
@@ -28,11 +28,11 @@ const PublicKeys = ({ setStepValidated }) => {
   };
 
   React.useEffect(() => {
-    if (!isLoading && (isError || (pubkeys && pubkeys.length < 1))) {
+    if (isError || pubkeys?.length < 1) {
       disableSelect(true);
       switchTo(NEW_KEY_OPTION);
     }
-  }, [isLoading]);
+  }, [isError, pubkeys]);
 
   return (
     <Form className="pubkeys">


### PR DESCRIPTION
This fixes the ssh authentication page after a failure and  editing the form. 

- [x] fix validation when editing the page
- [x] fix  disabled option 
- [x] add a unit test 
