### PR TITLE
refactor: Add custom ids to wizard buttons

### DIFF
--- a/src/Components/ProvisioningWizard/CustomFooter.js
+++ b/src/Components/ProvisioningWizard/CustomFooter.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Button, ButtonVariant, WizardFooter, WizardContextConsumer } from '@patternfly/react-core';
+import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
+
+import { stepIdToString } from './steps';
+
+const CustomFooter = () => (
+  <WizardFooter>
+    <WizardContextConsumer>
+      {({ activeStep, onNext, onBack, onClose }) => {
+        const isValid = activeStep.enableNext !== undefined ? activeStep.enableNext : true;
+
+        return (
+          <>
+            <Button
+              id={`wizard-provisioning-${stepIdToString(activeStep.id)}-next-button`}
+              variant={ButtonVariant.primary}
+              type="submit"
+              onClick={onNext}
+              isDisabled={!isValid}
+            >
+              {activeStep.nextButtonText || 'Next'}
+            </Button>
+            {!activeStep.hideBackButton && (
+              <Button
+                id={`wizard-provisioning-${stepIdToString(activeStep.id)}-back-button`}
+                variant={ButtonVariant.secondary}
+                onClick={onBack}
+                isDisabled={activeStep.id == 1}
+              >
+                Back
+              </Button>
+            )}
+            {!activeStep.hideCancelButton && (
+              <div className={styles.wizardFooterCancel}>
+                <Button variant={ButtonVariant.link} onClick={onClose}>
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </>
+        );
+      }}
+    </WizardContextConsumer>
+  </WizardFooter>
+);
+
+export default CustomFooter;

--- a/src/Components/ProvisioningWizard/index.js
+++ b/src/Components/ProvisioningWizard/index.js
@@ -4,8 +4,9 @@ import React from 'react';
 
 import { WizardProvider } from '../Common/WizardContext';
 import APIProvider from '../Common/Query';
-import defaultSteps from './steps';
 import ConfirmModal from '../ConfirmModal';
+import CustomFooter from './CustomFooter';
+import defaultSteps from './steps';
 import './steps/Pubkeys/pubkeys.scss';
 
 const DEFAULT_STEP_VALIDATION = {
@@ -59,6 +60,7 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
           onClose={onWizardClose}
           onNext={onNext}
           className={'provisioning'}
+          footer={<CustomFooter />}
         />
         <ConfirmModal isOpen={isConfirming} onConfirm={onCustomClose} onCancel={() => setConfirming(false)} />
       </APIProvider>

--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
@@ -161,7 +161,7 @@ const ReservationProgress = ({ imageID, setLaunchSuccess, provider }) => {
             )}
           </EmptyStateBody>
           {currentError && (
-            <Button onClick={() => goToStepById(1)} variant="primary">
+            <Button id="wizard-provisioning-failed-edit-button" onClick={() => goToStepById(1)} variant="primary">
               Edit
             </Button>
           )}

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -5,6 +5,14 @@ import PublicKeys from './Pubkeys';
 import FinishStep from './ReservationProgress';
 import { AWS_PROVIDER } from './ReservationProgress/constants';
 
+const stringIds = {
+  1: 'account',
+  4: 'sshkey',
+  5: 'review',
+};
+
+export const stepIdToString = (id) => stringIds[id];
+
 const defaultSteps = ({ stepIdReached, image: { name, id, architecture }, stepValidation, setStepValidation, setLaunchSuccess }) => [
   {
     name: 'Account and customization',


### PR DESCRIPTION
Add custom ids to Provisioning wizard.
The buttons needed a CustomHeader for the id to be set.

Fixes HMS-1127