### PR TITLE
build: remove node_modules from SonarQube scan

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -17,6 +17,7 @@ source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
 BUILD_RESULTS=$?
 
 SONAR_PR_CHECK="false"
+rm -r $WORKSPACE/node_modules # do not include npm packages in the scan
 source $WORKSPACE/.rhcicd/sonarqube.sh
 
 # Stubbed out for now

--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -39,6 +39,7 @@ export COMPONENT_NAME="provisioning-backend"
 source "${CICD_ROOT}/cji_smoke_test.sh"
 
 SONAR_PR_CHECK="true"
+rm -r $WORKSPACE/node_modules # do not include npm packages in the scan
 source $WORKSPACE/.rhcicd/sonarqube.sh
 
 source "${CICD_ROOT}/post_test_results.sh"


### PR DESCRIPTION
Even ignored it is noisy, lets nuke 'em