### PR TITLE
fix(HMS-1131): filter out regions with unsuccessful image clones

### DIFF
--- a/src/API/index.js
+++ b/src/API/index.js
@@ -34,6 +34,11 @@ export const fetchImageClones = async (composeID) => {
   return data;
 };
 
+export const fetchImageCloneStatus = async (cloneID) => {
+  const { data } = await axios.get(imageBuilderURL(`clones/${cloneID}`));
+  return data;
+};
+
 export const fetchReservationByProvider = async (reservationID, provider) => {
   const { data } = await axios.get(provisioningUrl(`reservations/${provider}/${reservationID}`));
   return data;

--- a/src/Components/RegionsSelect/RegionsSelect.test.js
+++ b/src/Components/RegionsSelect/RegionsSelect.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import RegionSelect from '.';
 import userEvent from '@testing-library/user-event';
 
-import { clonedImages, parentImage } from '../../mocks/fixtures/image.fixtures';
+import { clonedImages, failureCloneStatus, parentImage } from '../../mocks/fixtures/image.fixtures';
 import { render, screen } from '../../mocks/utils';
 import { imageBuilderURL } from '../../API/helpers';
 
@@ -12,6 +12,19 @@ describe('RegionSelect', () => {
     await mountSelectAndClick();
     const items = await screen.findAllByLabelText('Region item');
     expect(items).toHaveLength(clonedImages.meta.count + PARENT_IMAGE_COUNT);
+  });
+
+  test('filter out regions with unsuccessful cloned image', async () => {
+    const { server, rest } = window.msw;
+    server.use(
+      rest.get(imageBuilderURL(`clones/${clonedImages.data[0].id}`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(failureCloneStatus));
+      })
+    );
+    await mountSelectAndClick();
+    await screen.findByText(clonedImages.data[1].request.region);
+    const filteredRegion = screen.queryByText(clonedImages.data[0].request.region);
+    expect(filteredRegion).not.toBeInTheDocument();
   });
 
   test('no clones images', async () => {

--- a/src/mocks/fixtures/image.fixtures.js
+++ b/src/mocks/fixtures/image.fixtures.js
@@ -25,3 +25,6 @@ export const clonedImages = {
   ],
   meta: { count: 4 },
 };
+
+export const successfulCloneStatus = { status: 'success', type: 'aws' };
+export const failureCloneStatus = { status: 'failure', type: 'aws' };

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -3,7 +3,7 @@ import { imageBuilderURL, provisioningUrl } from '../API/helpers';
 import { instanceTypeList } from './fixtures/instanceTypes.fixtures';
 import { sourcesList } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
-import { clonedImages, parentImage } from './fixtures/image.fixtures';
+import { clonedImages, parentImage, successfulCloneStatus } from './fixtures/image.fixtures';
 import { AWSReservation, createdAWSReservation, reservation } from './fixtures/reservation.fixtures';
 
 export const handlers = [
@@ -18,6 +18,9 @@ export const handlers = [
   }),
   rest.get(imageBuilderURL(`composes/${parentImage.id}/clones`), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(clonedImages));
+  }),
+  rest.get(imageBuilderURL(`clones/:id`), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(successfulCloneStatus));
   }),
   rest.post(provisioningUrl('pubkeys'), (req, res, ctx) => {
     return res(ctx.status(200));


### PR DESCRIPTION
This PR filter out regions that the clone process ended unsuccessful
