### PR TITLE
fix(HMS-1361): fix a 404 api call at first rendering

### DIFF
--- a/src/Components/SourcesSelect/index.js
+++ b/src/Components/SourcesSelect/index.js
@@ -21,6 +21,7 @@ const SourcesSelect = ({ setValidation }) => {
     isLoading,
     data: sources,
   } = useQuery([SOURCES_QUERY_KEY, provider], () => fetchSourcesList(provider), {
+    enabled: !!provider,
     onSuccess: (data) => {
       const id = chosenSource;
 
@@ -45,8 +46,8 @@ const SourcesSelect = ({ setValidation }) => {
     setIsOpen(false);
   };
 
-  const selectItemsMapper = (sourcesData) =>
-    sourcesData.map(({ name, id }) => <SelectOption aria-label="Source account" key={id} value={selectObject(id, name)}></SelectOption>);
+  const selectItemsMapper = () =>
+    sources.map(({ name, id }) => <SelectOption aria-label="Source account" key={id} value={selectObject(id, name)}></SelectOption>);
 
   if (error) {
     console.warn('Failed to fetch sources list');
@@ -72,7 +73,7 @@ const SourcesSelect = ({ setValidation }) => {
       placeholderText="Select account"
       aria-label="Select account"
     >
-      {selectItemsMapper(sources)}
+      {sources && selectItemsMapper()}
     </Select>
   );
 };


### PR DESCRIPTION
the `provider` is undefined at first rendering,  causes an extra triggering of `/sources?provider=undefiend` which ended up with 404