### PR TITLE
Add support to a source shared with an image

### DIFF
--- a/src/Components/Common/constants.js
+++ b/src/Components/Common/constants.js
@@ -1,2 +1,3 @@
 export const AWS_PROVIDER = 'aws';
 export const GCP_PROVIDER = 'gcp';
+export const IB_SOURCE_PROVIDERS = [AWS_PROVIDER];

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
@@ -8,7 +8,7 @@ import InstanceTypesSelect from '../../../InstanceTypesSelect';
 import RegionsSelect from '../../../RegionsSelect';
 import { useWizardContext } from '../../../Common/WizardContext';
 
-const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID }) => {
+const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, imageSourceID }) => {
   const [{ chosenSource, chosenInstanceType }] = useWizardContext();
   const [validations, setValidation] = React.useState({
     sources: chosenSource ? 'success' : 'default',
@@ -37,6 +37,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID })
         fieldId="aws-select-source"
       >
         <SourcesSelect
+          imageSourceID={imageSourceID}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -131,6 +132,7 @@ AccountCustomizationsAWS.propTypes = {
   setStepValidated: PropTypes.func.isRequired,
   architecture: PropTypes.string.isRequired,
   composeID: PropTypes.string.isRequired,
+  imageSourceID: PropTypes.number.isRequired,
 };
 
 export default AccountCustomizationsAWS;

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
@@ -6,7 +6,7 @@ import { useWizardContext } from '../../../Common/WizardContext';
 import AWS from './aws';
 import GCP from './gcp';
 
-const AccountCustomizations = ({ setStepValidated, architecture, composeID, provider }) => {
+const AccountCustomizations = ({ setStepValidated, architecture, composeID, provider, imageSourceID }) => {
   const [, setWizardContext] = useWizardContext();
 
   React.useEffect(() => {
@@ -21,7 +21,7 @@ const AccountCustomizations = ({ setStepValidated, architecture, composeID, prov
 
   switch (provider) {
     case AWS_PROVIDER:
-      return <AWS setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} />;
+      return <AWS setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} imageSourceID={imageSourceID} />;
     case GCP_PROVIDER:
       return <GCP setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} />;
     default:
@@ -34,6 +34,7 @@ AccountCustomizations.propTypes = {
   architecture: PropTypes.string.isRequired,
   composeID: PropTypes.string.isRequired,
   provider: PropTypes.oneOf([AWS_PROVIDER, GCP_PROVIDER]),
+  imageSourceID: PropTypes.number,
 };
 
 export default AccountCustomizations;

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -13,7 +13,13 @@ const stringIds = {
 
 export const stepIdToString = (id) => stringIds[id];
 
-const defaultSteps = ({ stepIdReached, image: { name, id, architecture, provider }, stepValidation, setStepValidation, setLaunchSuccess }) => [
+const defaultSteps = ({
+  stepIdReached,
+  image: { name, id, architecture, provider, sourceId },
+  stepValidation,
+  setStepValidation,
+  setLaunchSuccess,
+}) => [
   {
     name: 'Account and customization',
     steps: [
@@ -26,6 +32,7 @@ const defaultSteps = ({ stepIdReached, image: { name, id, architecture, provider
             provider={provider}
             architecture={architecture || 'x86_64'}
             composeID={id}
+            imageSourceID={sourceId}
             setStepValidated={(validated) => setStepValidation((prev) => ({ ...prev, awsStep: validated }))}
           />
         ),

--- a/src/Components/SourcesSelect/SourcesSelect.test.js
+++ b/src/Components/SourcesSelect/SourcesSelect.test.js
@@ -4,10 +4,22 @@ import userEvent from '@testing-library/user-event';
 import { sourcesList } from '../../mocks/fixtures/sources.fixtures';
 import { render, screen } from '../../mocks/utils';
 
+const mockContext = require('../Common/WizardContext/initialState');
+
 describe('SourcesSelect', () => {
-  test('preselects the chosen source', async () => {
-    render(<SourcesSelect setValidation={jest.fn()} />);
+  test('preselect aws source', async () => {
+    render(<SourcesSelect imageSourceID={1} setValidation={jest.fn()} />);
     // wizard context mock is `{chosenSource: 1}`
+    const selectDropdown = await screen.findByText('Source 1');
+    await userEvent.click(selectDropdown);
+  });
+
+  test('preselects the chosen source', async () => {
+    jest.mock('../Common/WizardContext/initialState', () => ({
+      __esModule: true,
+      default: { ...mockContext, provider: 'gcp' },
+    }));
+    render(<SourcesSelect setValidation={jest.fn()} />);
     const selectDropdown = await screen.findByText('Source 1');
     await userEvent.click(selectDropdown);
 

--- a/src/Components/SourcesSelect/index.js
+++ b/src/Components/SourcesSelect/index.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert, Select, SelectOption, Spinner } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
-
 import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
 import { useWizardContext } from '../Common/WizardContext';
+import { IB_SOURCE_PROVIDERS } from '../Common/constants';
 
-const SourcesSelect = ({ setValidation }) => {
+const SourcesSelect = ({ setValidation, imageSourceID }) => {
   const [{ provider, chosenSource }, setWizardContext] = useWizardContext();
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(null);
@@ -25,8 +25,18 @@ const SourcesSelect = ({ setValidation }) => {
     onSuccess: (data) => {
       const id = chosenSource;
 
-      if (!id) return;
-      setSelected(selectObject(id, data.find((source) => source.id === id).name));
+      if (IB_SOURCE_PROVIDERS.includes(provider) && imageSourceID) {
+        setSelected(selectObject(imageSourceID, data.find((source) => source.id === imageSourceID).name));
+        setWizardContext((prevState) => ({
+          ...prevState,
+          chosenSource: imageSourceID,
+        }));
+        setValidation('success');
+      } else if (!id) {
+        return;
+      } else {
+        setSelected(selectObject(id, data.find((source) => source.id === id).name));
+      }
     },
   });
 
@@ -69,6 +79,7 @@ const SourcesSelect = ({ setValidation }) => {
       isOpen={isOpen}
       onToggle={(openState) => setIsOpen(openState)}
       selections={selected}
+      isDisabled={!!imageSourceID}
       onSelect={onSelect}
       placeholderText="Select account"
       aria-label="Select account"
@@ -80,6 +91,7 @@ const SourcesSelect = ({ setValidation }) => {
 
 SourcesSelect.propTypes = {
   setValidation: PropTypes.func.isRequired,
+  imageSourceID: PropTypes.number,
 };
 
 export default SourcesSelect;


### PR DESCRIPTION
This PR matches Image builder change to share images with a source rather than an account ID (AWS for now). 
Image builder have added a prop name: sourceId on their side. (currently, image builder UI supports only sharing with one source and the provisioning service as well)
In this PR we are preselecting the source to the one given by IB, and showing it as disabled (You cannot change the source from the dropdown). 
This addition currently is only for AWS, in GCP and Azure the source should be selected from the dropdown. 

_Good To Know:_ 
After the change IB did it is **not possible** to use sources locally, you should use sources stage, make sure you have added a source there. 
If the image was not shared with a source the Launch button is not going to appear. (in AWS we do not allow (for now?) an image to be shared with an account id)
![image](https://user-images.githubusercontent.com/57755873/225610863-754b6cba-85af-4fd6-bb85-b039a19e484a.png)

