### PR TITLE
Add ouid for Card on show additional info

### DIFF
--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/ExpansionInfo.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/ExpansionInfo.js
@@ -27,7 +27,7 @@ const ExpandedInfo = ({ reservationID, error, createdAt }) => {
     <Bullseye>
       <ExpandableSection toggleTextCollapsed="Show additional info" toggleTextExpanded="">
         <DescriptionList columnModifier={{ lg: '2Col' }}>
-          <Card component="div">
+          <Card component="div" ouiaId="launch_id">
             <DescriptionListTerm>Launch ID</DescriptionListTerm>
             <DescriptionListDescription>{<span aria-label="launch id">{reservationID}</span>}</DescriptionListDescription>
           </Card>


### PR DESCRIPTION
Instead of picking `reservation_id`(hidden) in the iqe test, add ouid and looking for the Card in show additional info launch_id makes more sense in the test