### PR TITLE
feat: add empty state when no source available

### DIFF
--- a/src/API/index.js
+++ b/src/API/index.js
@@ -16,6 +16,11 @@ export const fetchSourcesList = async (provider) => {
   return data;
 };
 
+export const fetchSourceUploadInfo = async (sourceID) => {
+  const { data } = await axios.get(provisioningUrl(`sources/${sourceID}/upload_info`));
+  return data;
+};
+
 export const fetchPubkeysList = async () => {
   const { data } = await axios.get(provisioningUrl('pubkeys'));
   return data;

--- a/src/API/queryKeys.js
+++ b/src/API/queryKeys.js
@@ -1,4 +1,5 @@
-export const SOURCES_QUERY_KEY = 'sources';
+export const sourcesQueryKey = (provider) => ['sources', provider];
+export const sourceUploadInfoKey = (source_id) => ['source_upload_info', source_id];
 export const PUBKEYS_QUERY_KEY = 'pubkeys';
 export const instanceTypesQueryKeys = (region) => ['instanceTypes', region];
 export const IMAGE_REGIONS_KEY = 'image_region';

--- a/src/Components/LaunchDescriptionList/index.js
+++ b/src/Components/LaunchDescriptionList/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { ExpandableSection, DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription } from '@patternfly/react-core';
 
 import { useQuery } from 'react-query';
-import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
+import { sourcesQueryKey } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
 import { useWizardContext } from '../Common/WizardContext';
 import { instanceType, region } from '../ProvisioningWizard/steps/ReservationProgress/helpers';
@@ -11,7 +11,7 @@ import { instanceType, region } from '../ProvisioningWizard/steps/ReservationPro
 const LaunchDescriptionList = ({ imageName }) => {
   const [{ chosenRegion, chosenSshKeyName, uploadedKey, chosenInstanceType, chosenNumOfInstances, chosenSource, sshPublicName, provider }] =
     useWizardContext();
-  const { data: sources } = useQuery([SOURCES_QUERY_KEY, provider], () => fetchSourcesList(provider));
+  const { data: sources } = useQuery(sourcesQueryKey(provider), () => fetchSourcesList(provider));
   const [isExpanded, setIsExpanded] = React.useState(true);
   const onToggle = (isExpanded) => {
     setIsExpanded(isExpanded);

--- a/src/Components/ProvisioningWizard/helpers.js
+++ b/src/Components/ProvisioningWizard/helpers.js
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import { useQuery, useQueries } from 'react-query';
+
+import { sourcesQueryKey, sourceUploadInfoKey } from '../../API/queryKeys';
+import { fetchSourcesList, fetchSourceUploadInfo } from '../../API';
+import { AWS_PROVIDER, AZURE_PROVIDER } from '../../constants';
+
+export const imageProps = PropTypes.shape({
+  name: PropTypes.string,
+  id: PropTypes.string,
+  provider: PropTypes.string,
+  architecture: PropTypes.string,
+  sourceIDs: PropTypes.arrayOf(PropTypes.string),
+  accountIDs: PropTypes.arrayOf(PropTypes.string),
+}).isRequired;
+
+export const sourcesData = (image, { refetch = false } = {}) => {
+  const {
+    error,
+    isLoading,
+    data: sources,
+  } = useQuery(sourcesQueryKey(image.provider), () => fetchSourcesList(image.provider), {
+    enabled: !!image.provider,
+    refetchInterval: refetch && 10000,
+  });
+  return { error, isLoading, sources };
+};
+
+const loadSourcesUploadInfos = (image, { refetch }) => {
+  const { sources, isLoading: isLoadingSources, error: sourcesError } = sourcesData(image, { refetch });
+
+  const uploadInfos = useQueries(
+    sources?.map((source) => ({ queryKey: sourceUploadInfoKey(source.id), queryFn: () => fetchSourceUploadInfo(source.id), retry: 1 })) || []
+  );
+
+  const isLoading = isLoadingSources || uploadInfos.every((info) => info.isLoading);
+  const infos = [];
+  sources?.forEach((source, i) => {
+    uploadInfos[i].isSuccess && infos.push({ ...uploadInfos[i].data, source_id: source.id });
+  });
+
+  return { isLoading, error: sourcesError, infos };
+};
+
+const providerSourceFilter = (image) => {
+  switch (image.provider) {
+    case AWS_PROVIDER:
+      return (info) => image.sourceIDs?.includes(info.source_id) || image.accountIDs?.includes(info.aws.account_id);
+    case AZURE_PROVIDER:
+      return (info) => image.sourceIDs?.includes(info.source_id) || info.azure?.subscription_id === image.uploadOptions?.subscription_id;
+    default:
+      return (info) => image.sourceIDs?.includes(info.source_id);
+  }
+};
+
+export const sourcesForImage = (image, { refetch = false } = {}) => {
+  const { isLoading, error, infos } = loadSourcesUploadInfos(image, { refetch });
+
+  if (isLoading || error) return { isLoading, error, sources: [] };
+  const filteredSources = image.isTesting ? infos : infos.filter(providerSourceFilter(image));
+
+  return { isLoading, error, sources: filteredSources };
+};

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
@@ -37,7 +37,7 @@ AccountCustomizations.propTypes = {
   architecture: PropTypes.string.isRequired,
   composeID: PropTypes.string.isRequired,
   provider: PropTypes.oneOf([AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER]),
-  imageSourceID: PropTypes.number,
+  imageSourceID: PropTypes.string,
 };
 
 export default AccountCustomizations;

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -1,21 +1,22 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, Bullseye, Stack, StackItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../../constants';
+import RegionsSelect from '../../../RegionsSelect';
 import { imageProps } from '../../helpers.js';
 
 const DirectProviderLink = ({ image }) => {
   // TODO
   const uploadStatus = image.uploadStatus || { options: {} };
   const uploadOptions = image.uploadOptions || {};
+  const [currentImage, setImage] = React.useState({ imageID: image.id, ...uploadStatus.options });
   let url, text;
 
   switch (image.provider) {
     case AWS_PROVIDER:
       text = 'Launch with AWS console';
-      url =
-        'https://console.aws.amazon.com/ec2/v2/home?region=' + uploadStatus.options.region + '#LaunchInstanceWizard:ami=' + uploadStatus.options.ami;
+      url = 'https://console.aws.amazon.com/ec2/v2/home?region=' + currentImage.region + '#LaunchInstanceWizard:ami=' + currentImage.ami;
       break;
     case AZURE_PROVIDER:
       text = 'View uploaded image';
@@ -33,10 +34,27 @@ const DirectProviderLink = ({ image }) => {
       throw new Error(`Steps requested for unknown provider: ${image.provider}`);
   }
 
+  // Currently only AWS, so the ami is hardcoded
+  const onRegionChange = (image) => {
+    console.log(image);
+    setImage(image);
+  };
+
   return (
-    <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>
-      {text}
-    </Button>
+    <Stack>
+      <StackItem>
+        <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>
+          {text}
+        </Button>
+      </StackItem>
+      {image.provider === AWS_PROVIDER && (
+        <StackItem>
+          <Bullseye>
+            <RegionsSelect composeID={image.id} provider={image.provider} currentRegion={currentImage.region} onChange={onRegionChange} />
+          </Bullseye>
+        </StackItem>
+      )}
+    </Stack>
   );
 };
 

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../../constants';
+import { imageProps } from '../../helpers.js';
+
+const DirectProviderLink = ({ image }) => {
+  // TODO
+  const uploadStatus = image.uploadStatus || { options: {} };
+  const uploadOptions = image.uploadOptions || {};
+  let url, text;
+
+  switch (image.provider) {
+    case AWS_PROVIDER:
+      text = 'Launch with AWS console';
+      url =
+        'https://console.aws.amazon.com/ec2/v2/home?region=' + uploadStatus.options.region + '#LaunchInstanceWizard:ami=' + uploadStatus.options.ami;
+      break;
+    case AZURE_PROVIDER:
+      text = 'View uploaded image';
+      url =
+        'https://portal.azure.com/#@' +
+        uploadOptions.tenant_id +
+        '/resource/subscriptions/' +
+        uploadOptions.subscription_id +
+        '/resourceGroups/' +
+        uploadOptions.resource_group +
+        '/providers/Microsoft.Compute/images/' +
+        uploadStatus.options.image_name;
+      break;
+    default:
+      throw new Error(`Steps requested for unknown provider: ${image.provider}`);
+  }
+
+  return (
+    <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>
+      {text}
+    </Button>
+  );
+};
+
+DirectProviderLink.propTypes = {
+  image: imageProps,
+};
+
+export default DirectProviderLink;

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import SourceMissing from '.';
+
+import { render, screen } from '../../../../mocks/utils';
+
+describe('Source missing', () => {
+  describe('Loading state', () => {
+    test('shows loading state', () => {
+      render(<SourceMissing isLoading image={{ provider: 'aws' }} />);
+      expect(screen.getByText(/Loading available Sources/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('AWS', () => {
+    const awsImage = {
+      provider: 'aws',
+      uploadStatus: {
+        options: { region: 'us-east-1', ami: 'ami-123123' },
+      },
+    };
+
+    test('has create source button', () => {
+      render(<SourceMissing image={awsImage} />);
+
+      const sourcesLink = screen.getByRole('link', { name: 'Create Source' });
+      expect(sourcesLink).toHaveAttribute('href', '/settings/sources/new');
+    });
+
+    test('renders direct link', () => {
+      render(<SourceMissing image={awsImage} />);
+
+      const directLink = screen.getByRole('link', { name: 'Launch with AWS console' });
+      expect(directLink).toHaveAttribute(
+        'href',
+        `https://console.aws.amazon.com/ec2/v2/home?region=${awsImage.uploadStatus.options.region}#LaunchInstanceWizard:ami=${awsImage.uploadStatus.options.ami}`
+      );
+    });
+  });
+
+  describe('Azure', () => {
+    const azureImage = {
+      provider: 'azure',
+      uploadStatus: { options: { image_name: 'cool-image' } },
+      uploadOptions: { tenant_id: '123', subscription_id: '321', resource_group: 'testGroup' },
+    };
+
+    test('has create source button', () => {
+      render(<SourceMissing image={azureImage} />);
+
+      const sourcesLink = screen.getByRole('link', { name: 'Create Source' });
+      expect(sourcesLink).toHaveAttribute('href', '/settings/sources/new');
+    });
+
+    test('renders direct link', () => {
+      render(<SourceMissing image={azureImage} />);
+
+      const url =
+        'https://portal.azure.com/#@' +
+        azureImage.uploadOptions.tenant_id +
+        '/resource/subscriptions/' +
+        azureImage.uploadOptions.subscription_id +
+        '/resourceGroups/' +
+        azureImage.uploadOptions.resource_group +
+        '/providers/Microsoft.Compute/images/' +
+        azureImage.uploadStatus.options.image_name;
+
+      const directLink = screen.getByRole('link', { name: 'View uploaded image' });
+      expect(directLink).toHaveAttribute('href', url);
+    });
+  });
+});

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateSecondaryActions, Title, Spinner } from '@patternfly/react-core';
+import { PlusCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import DirectProviderLink from './DirectProviderLink';
+import { imageProps } from '../../helpers.js';
+
+const failedToFetchTitle = 'Failed to fetch available sources.';
+const missingSourceTitle = 'No sources available';
+const missingSourceDescription =
+  'There are no sources available for use with this image. ' +
+  'Create a source, grant an existing source launch functionality, ' +
+  'or launch directly from the cloud provider console.';
+// TODO: enable once documentation is available.
+// Learn more about launching images [external link icon].
+
+const LoadingState = () => (
+  <EmptyState>
+    <EmptyStateIcon variant="container" component={Spinner} />
+    <Title size="lg" headingLevel="h4">
+      Loading available Sources
+    </Title>
+  </EmptyState>
+);
+
+const SourceMissing = ({ error, image }) => (
+  <EmptyState>
+    <EmptyStateIcon icon={error ? ExclamationCircleIcon : PlusCircleIcon} />
+    <Title headingLevel="h4" size="lg">
+      {(error && failedToFetchTitle) || missingSourceTitle}
+    </Title>
+    <EmptyStateBody>{error || missingSourceDescription}</EmptyStateBody>
+    <Button variant="primary" component="a" target="_blank" href="/settings/sources/new">
+      Create Source
+    </Button>
+    <EmptyStateSecondaryActions>
+      <DirectProviderLink image={image} />
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+);
+
+SourceMissing.propTypes = {
+  error: PropTypes.string,
+  image: imageProps,
+};
+
+const LoadingWrapper = ({ isLoading, ...props }) => (isLoading ? <LoadingState /> : <SourceMissing {...props} />);
+
+LoadingWrapper.propTypes = {
+  error: PropTypes.string,
+  isLoading: PropTypes.bool,
+  image: imageProps,
+};
+
+export default LoadingWrapper;

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import AccountCustomizations from '../steps/AccountCustomizations';
+import SourceMissing from './SourceMissing';
+import AccountCustomizations from './AccountCustomizations';
 import ReviewDetails from './ReviewDetails';
 import PublicKeys from './Pubkeys';
 import FinishStep from './ReservationProgress';
@@ -13,9 +14,18 @@ const stringIds = {
 
 export const stepIdToString = (id) => stringIds[id];
 
-const defaultSteps = ({
+const missingSource = ({ image, isLoading, sourcesError }) => [
+  {
+    name: 'Define source',
+    id: 1,
+    component: <SourceMissing image={image} isLoading={isLoading} error={sourcesError} />,
+    isFinishedStep: true,
+  },
+];
+
+const wizardSteps = ({
   stepIdReached,
-  image: { name, id, architecture, provider, sourceId },
+  image: { name, id, architecture, provider, sourceIDs },
   stepValidation,
   setStepValidation,
   setLaunchSuccess,
@@ -32,7 +42,7 @@ const defaultSteps = ({
             provider={provider}
             architecture={architecture || 'x86_64'}
             composeID={id}
-            imageSourceID={sourceId}
+            imageSourceID={sourceIDs?.[0]}
             setStepValidated={(validated) => setStepValidation((prev) => ({ ...prev, awsStep: validated }))}
           />
         ),
@@ -62,4 +72,6 @@ const defaultSteps = ({
   },
 ];
 
-export default defaultSteps;
+const steps = (props) => (!props.isLoading && props.availableSources.length > 0 ? wizardSteps(props) : missingSource(props));
+
+export default steps;

--- a/src/Components/RegionsSelect/index.js
+++ b/src/Components/RegionsSelect/index.js
@@ -29,12 +29,17 @@ const RegionsSelect = ({ provider, currentRegion, composeID, onChange }) => {
   // filter successful clones images
   if (clonesStatusQueries.length && clonesStatusQueries.every((cloneQuery) => cloneQuery.isLoading === false)) {
     const clonesStatus = clonesStatusQueries?.map((query) => query?.data);
-    const filteredCloned = clonedImages?.filter((_, index) => clonesStatus[index].status === 'success');
-    images.push(...filteredCloned);
+    // enrich the cloned image data
+    clonesStatus?.forEach((status, index) => {
+      clonedImages[index] = { ...clonedImages[index], ...status?.options };
+    });
+    const availableImages = clonedImages?.filter((_, index) => clonesStatus[index].status === 'success');
+    images.push(...availableImages);
   }
 
   const onSelect = (_, selection) => {
-    onChange({ region: selection, imageID: images.find((image) => image.region === selection)?.id });
+    const { id: imageID, ...imageAttrs } = images.find((image) => image.region === selection);
+    onChange({ region: selection, imageID, ...imageAttrs });
     setIsOpen(false);
   };
 

--- a/src/Components/SourcesSelect/index.js
+++ b/src/Components/SourcesSelect/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert, Select, SelectOption, Spinner } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
-import { SOURCES_QUERY_KEY } from '../../API/queryKeys';
+import { sourcesQueryKey } from '../../API/queryKeys';
 import { fetchSourcesList } from '../../API';
 import { useWizardContext } from '../Common/WizardContext';
 import { IB_SOURCE_PROVIDERS } from '../Common/constants';
@@ -20,7 +20,7 @@ const SourcesSelect = ({ setValidation, imageSourceID }) => {
     error,
     isLoading,
     data: sources,
-  } = useQuery([SOURCES_QUERY_KEY, provider], () => fetchSourcesList(provider), {
+  } = useQuery(sourcesQueryKey(provider), () => fetchSourcesList(provider), {
     enabled: !!provider,
     onSuccess: (data) => {
       const id = chosenSource;
@@ -91,7 +91,7 @@ const SourcesSelect = ({ setValidation, imageSourceID }) => {
 
 SourcesSelect.propTypes = {
   setValidation: PropTypes.func.isRequired,
-  imageSourceID: PropTypes.number,
+  imageSourceID: PropTypes.string,
 };
 
 export default SourcesSelect;

--- a/src/Routes/SamplePage/SamplePage.js
+++ b/src/Routes/SamplePage/SamplePage.js
@@ -20,6 +20,7 @@ const SamplePage = () => {
   const [isWizardOpen, setWizardModal] = React.useState(false);
   const [images, setImages] = React.useState([]);
   const [chosenImage, setChosenImage] = React.useState({
+    isTesting: true,
     id: undefined,
     name: undefined,
     provider: AWS_PROVIDER,
@@ -51,7 +52,7 @@ const SamplePage = () => {
     if (isPlaceholder) return;
     const { id, request } = images.find((image) => image.image_name === selection);
     const { architecture, image_type } = request.image_requests[0];
-    setChosenImage({ id: id, name: selection, architecture: architecture, provider: image_type });
+    setChosenImage({ isTesting: true, id: id, name: selection, architecture: architecture, provider: image_type });
     setImageSelect(false);
   };
 


### PR DESCRIPTION
Adds empty state when no Source that can Launch given image is found. Provides link to Source creation.
Makes sure to refetch the empty state regularly so users do not need to refresh page. Adds fallback link for users who want to launch through cloud providers console directly.

Refs HMS-1583

NEW only empty state update - with region: 
[Screencast from 2023-04-13 14-02-44.webm](https://user-images.githubusercontent.com/2884324/231752847-2c5abab5-3ed3-43c7-a022-69d9ce0b62fb.webm)

~~Old: [Screencast from 2023-04-07 01-08-48.webm](https://user-images.githubusercontent.com/2884324/230512943-f3717717-9c06-4545-b08c-2975f60a4fee.webm)~~


- [x] ~Depends on~: https://github.com/RedHatInsights/image-builder-frontend/pull/1061