### PR TITLE
feat: filter source in the select

### DIFF
--- a/src/API/queryKeys.js
+++ b/src/API/queryKeys.js
@@ -1,5 +1,5 @@
-export const sourcesQueryKey = (provider) => ['sources', provider];
-export const sourceUploadInfoKey = (source_id) => ['source_upload_info', source_id];
+export const SOURCES_QUERY_KEY = 'sources';
+export const SOURCE_UPLOAD_INFO_KEY = 'source_upload_info';
 export const PUBKEYS_QUERY_KEY = 'pubkeys';
 export const instanceTypesQueryKeys = (region) => ['instanceTypes', region];
 export const IMAGE_REGIONS_KEY = 'image_region';

--- a/src/Components/Common/Hooks/sources.js
+++ b/src/Components/Common/Hooks/sources.js
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useQuery, useQueries } from 'react-query';
+
+import { SOURCES_QUERY_KEY, SOURCE_UPLOAD_INFO_KEY } from '../../../API/queryKeys';
+import { fetchSourcesList, fetchSourceUploadInfo } from '../../../API';
+import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../constants';
+
+export const imageProps = PropTypes.shape({
+  name: PropTypes.string,
+  id: PropTypes.string,
+  provider: PropTypes.string,
+  architecture: PropTypes.string,
+  sourceIDs: PropTypes.arrayOf(PropTypes.string),
+  accountIDs: PropTypes.arrayOf(PropTypes.string),
+}).isRequired;
+
+export const useSourcesData = (provider, { refetch = false } = {}) => {
+  const {
+    error,
+    isLoading,
+    data: sources,
+  } = useQuery([SOURCES_QUERY_KEY, provider], () => fetchSourcesList(provider), {
+    enabled: !!provider,
+    refetchInterval: refetch && 10000,
+  });
+  return { error, isLoading, sources };
+};
+
+const useSourcesUploadInfos = (provider, { refetch }) => {
+  const { sources, isLoading: isLoadingSources, error: sourcesError } = useSourcesData(provider, { refetch });
+
+  const uploadInfos = useQueries(
+    sources?.map((source) => ({ queryKey: [SOURCE_UPLOAD_INFO_KEY, source.id], queryFn: () => fetchSourceUploadInfo(source.id), retry: 1 })) || []
+  );
+
+  const isLoading = isLoadingSources || uploadInfos.some((info) => info.isLoading);
+  const infos = [];
+  !isLoading &&
+    sources?.forEach((source, i) => {
+      uploadInfos[i].isSuccess && infos.push({ ...uploadInfos[i].data, ...source });
+    });
+
+  return { isLoading, error: sourcesError, infos };
+};
+
+const providerSourceFilter = (image) => {
+  switch (image.provider) {
+    case AWS_PROVIDER:
+      return (info) => image.sourceIDs?.includes(info.id) || image.accountIDs?.includes(info.aws.account_id);
+    case AZURE_PROVIDER:
+      return (info) => image.uploadOptions?.source_id === info.id || info.azure?.subscription_id === image.uploadOptions?.subscription_id;
+    default:
+      return (info) => image.sourceIDs?.includes(info.id);
+  }
+};
+
+export const useSourcesForImage = (image, { refetch = false, onSuccess = () => {} } = {}) => {
+  const { isLoading, error, infos } = useSourcesUploadInfos(image.provider, { refetch });
+
+  React.useEffect(() => {
+    if (!isLoading && !error) {
+      onSuccess(filteredSources);
+    }
+  }, [isLoading, error]);
+
+  const filteredSources = image.isTesting ? infos : infos?.filter(providerSourceFilter(image));
+  return { isLoading, error, sources: filteredSources || [] };
+};

--- a/src/Components/Common/WizardContext/__mocks__/initialState.js
+++ b/src/Components/Common/WizardContext/__mocks__/initialState.js
@@ -1,5 +1,5 @@
 const initialWizardContext = {
-  chosenSource: 1,
+  chosenSource: undefined,
   provider: 'aws',
   chosenRegion: 'us-east-1',
 };

--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -47,7 +47,7 @@ describe('InstanceTypesSelect', () => {
 });
 
 const mountSelectAndClick = async (provider = 'aws') => {
-  render(<InstanceTypesSelect architecture="x86_64" setValidation={jest.fn()} />, { provider });
+  render(<InstanceTypesSelect architecture="x86_64" setValidation={jest.fn()} />, { provider, contextValues: { chosenSource: '1' } });
   const selectDropdown = await screen.findByPlaceholderText('Select instance type');
   await userEvent.click(selectDropdown);
   return selectDropdown;

--- a/src/Components/LaunchDescriptionList/index.js
+++ b/src/Components/LaunchDescriptionList/index.js
@@ -2,16 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { ExpandableSection, DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription } from '@patternfly/react-core';
 
-import { useQuery } from 'react-query';
-import { sourcesQueryKey } from '../../API/queryKeys';
-import { fetchSourcesList } from '../../API';
+import { useSourcesData } from '../Common/Hooks/sources';
 import { useWizardContext } from '../Common/WizardContext';
 import { instanceType, region } from '../ProvisioningWizard/steps/ReservationProgress/helpers';
 
 const LaunchDescriptionList = ({ imageName }) => {
   const [{ chosenRegion, chosenSshKeyName, uploadedKey, chosenInstanceType, chosenNumOfInstances, chosenSource, sshPublicName, provider }] =
     useWizardContext();
-  const { data: sources } = useQuery(sourcesQueryKey(provider), () => fetchSourcesList(provider));
+  const { sources } = useSourcesData(provider);
   const [isExpanded, setIsExpanded] = React.useState(true);
   const onToggle = (isExpanded) => {
     setIsExpanded(isExpanded);

--- a/src/Components/ProvisioningWizard/helpers.js
+++ b/src/Components/ProvisioningWizard/helpers.js
@@ -1,63 +1,12 @@
 import PropTypes from 'prop-types';
-import { useQuery, useQueries } from 'react-query';
 
-import { sourcesQueryKey, sourceUploadInfoKey } from '../../API/queryKeys';
-import { fetchSourcesList, fetchSourceUploadInfo } from '../../API';
-import { AWS_PROVIDER, AZURE_PROVIDER } from '../../constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../constants';
 
 export const imageProps = PropTypes.shape({
   name: PropTypes.string,
   id: PropTypes.string,
-  provider: PropTypes.string,
+  provider: PropTypes.oneOf([AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER]),
   architecture: PropTypes.string,
   sourceIDs: PropTypes.arrayOf(PropTypes.string),
   accountIDs: PropTypes.arrayOf(PropTypes.string),
 }).isRequired;
-
-export const sourcesData = (image, { refetch = false } = {}) => {
-  const {
-    error,
-    isLoading,
-    data: sources,
-  } = useQuery(sourcesQueryKey(image.provider), () => fetchSourcesList(image.provider), {
-    enabled: !!image.provider,
-    refetchInterval: refetch && 10000,
-  });
-  return { error, isLoading, sources };
-};
-
-const loadSourcesUploadInfos = (image, { refetch }) => {
-  const { sources, isLoading: isLoadingSources, error: sourcesError } = sourcesData(image, { refetch });
-
-  const uploadInfos = useQueries(
-    sources?.map((source) => ({ queryKey: sourceUploadInfoKey(source.id), queryFn: () => fetchSourceUploadInfo(source.id), retry: 1 })) || []
-  );
-
-  const isLoading = isLoadingSources || uploadInfos.every((info) => info.isLoading);
-  const infos = [];
-  sources?.forEach((source, i) => {
-    uploadInfos[i].isSuccess && infos.push({ ...uploadInfos[i].data, source_id: source.id });
-  });
-
-  return { isLoading, error: sourcesError, infos };
-};
-
-const providerSourceFilter = (image) => {
-  switch (image.provider) {
-    case AWS_PROVIDER:
-      return (info) => image.sourceIDs?.includes(info.source_id) || image.accountIDs?.includes(info.aws.account_id);
-    case AZURE_PROVIDER:
-      return (info) => image.uploadOptions?.source_id === info.source_id || info.azure?.subscription_id === image.uploadOptions?.subscription_id;
-    default:
-      return (info) => image.sourceIDs?.includes(info.source_id);
-  }
-};
-
-export const sourcesForImage = (image, { refetch = false } = {}) => {
-  const { isLoading, error, infos } = loadSourcesUploadInfos(image, { refetch });
-
-  if (isLoading || error) return { isLoading, error, sources: [] };
-  const filteredSources = image.isTesting ? infos : infos.filter(providerSourceFilter(image));
-
-  return { isLoading, error, sources: filteredSources };
-};

--- a/src/Components/ProvisioningWizard/index.js
+++ b/src/Components/ProvisioningWizard/index.js
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import { Wizard } from '@patternfly/react-core';
 import React from 'react';
 
-import { WizardProvider } from '../Common/WizardContext';
 import APIProvider from '../Common/Query';
+import { WizardProvider } from '../Common/WizardContext';
+import { useSourcesForImage } from '../Common/Hooks/sources';
 import ConfirmModal from '../ConfirmModal';
 import CustomFooter from './CustomFooter';
-import { imageProps, sourcesForImage } from './helpers';
+import { imageProps } from './helpers';
 import getSteps from './steps';
 import './steps/Pubkeys/pubkeys.scss';
 
@@ -21,7 +22,7 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
   const [isConfirming, setConfirming] = React.useState(false);
   const [successfulLaunch, setLaunchSuccess] = React.useState();
 
-  const { isLoading, error: sourcesError, sources: availableSources } = sourcesForImage(image, { refetch: stepIdReached <= 2 });
+  const { isLoading, error: sourcesError, sources: availableSources } = useSourcesForImage(image, { refetch: stepIdReached <= 2 });
 
   const onCustomClose = () => {
     setConfirming(false);
@@ -55,7 +56,7 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
   };
 
   return (
-    <WizardProvider>
+    <>
       <Wizard
         {...props}
         title="Launch"
@@ -68,11 +69,15 @@ const ProvisioningWizard = ({ isOpen, onClose, image, ...props }) => {
         footer={<CustomFooter />}
       />
       <ConfirmModal isOpen={isConfirming} onConfirm={onCustomClose} onCancel={() => setConfirming(false)} />
-    </WizardProvider>
+    </>
   );
 };
 
-const ProvisioningWizardWrapper = (props) => <APIProvider>{props.isOpen && <ProvisioningWizard {...props} />}</APIProvider>;
+const ProvisioningWizardWrapper = (props) => (
+  <WizardProvider>
+    <APIProvider>{props.isOpen && <ProvisioningWizard {...props} />}</APIProvider>
+  </WizardProvider>
+);
 
 ProvisioningWizard.propTypes = {
   isOpen: PropTypes.bool.isRequired,

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
@@ -5,6 +5,7 @@ import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { useFlag } from '@unleash/proxy-client-react';
 
 import { AWS_PROVIDER } from '../../../../constants';
+import { imageProps } from '../../helpers';
 import SourcesSelect from '../../../SourcesSelect';
 import InstanceCounter from '../../../InstanceCounter';
 import InstanceTypesSelect from '../../../InstanceTypesSelect';
@@ -12,7 +13,7 @@ import RegionsSelect from '../../../RegionsSelect';
 import { useWizardContext } from '../../../Common/WizardContext';
 import TemplatesSelect from '../../../TemplateSelect';
 
-const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, imageSourceID }) => {
+const AccountCustomizationsAWS = ({ setStepValidated, image }) => {
   const [{ chosenSource, chosenRegion, chosenInstanceType }, setWizardContext] = useWizardContext();
   const [validations, setValidation] = React.useState({
     sources: chosenSource ? 'success' : 'default',
@@ -50,7 +51,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, i
         fieldId="aws-select-source"
       >
         <SourcesSelect
-          imageSourceID={imageSourceID}
+          image={image}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -79,7 +80,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, i
           </Popover>
         }
       >
-        <RegionsSelect provider={AWS_PROVIDER} onChange={onRegionChange} composeID={composeID} currentRegion={chosenRegion} />
+        <RegionsSelect provider={AWS_PROVIDER} onChange={onRegionChange} composeID={image.id} currentRegion={chosenRegion} />
       </FormGroup>
       {templateFlag && (
         <FormGroup
@@ -139,7 +140,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, i
         }
       >
         <InstanceTypesSelect
-          architecture={architecture}
+          architecture={image.architecture}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -176,9 +177,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, architecture, composeID, i
 
 AccountCustomizationsAWS.propTypes = {
   setStepValidated: PropTypes.func.isRequired,
-  architecture: PropTypes.string.isRequired,
-  composeID: PropTypes.string.isRequired,
-  imageSourceID: PropTypes.number.isRequired,
+  image: imageProps,
 };
 
 export default AccountCustomizationsAWS;

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
@@ -4,13 +4,14 @@ import { Form, FormGroup, Popover, Title, Text, Button } from '@patternfly/react
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 import { AZURE_PROVIDER } from '../../../../constants';
+import { imageProps } from '../../helpers';
 import SourcesSelect from '../../../SourcesSelect';
 import InstanceCounter from '../../../InstanceCounter';
 import InstanceTypesSelect from '../../../InstanceTypesSelect';
 import RegionsSelect from '../../../RegionsSelect';
 import { useWizardContext } from '../../../Common/WizardContext';
 
-const AccountCustomizationsAzure = ({ setStepValidated, architecture, composeID }) => {
+const AccountCustomizationsAzure = ({ setStepValidated, image }) => {
   const [wizardContext, setWizardContext] = useWizardContext();
   const [validations, setValidation] = React.useState({
     sources: wizardContext.chosenSource ? 'success' : 'default',
@@ -47,6 +48,7 @@ const AccountCustomizationsAzure = ({ setStepValidated, architecture, composeID 
         fieldId="azure-select-source"
       >
         <SourcesSelect
+          image={image}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -75,7 +77,7 @@ const AccountCustomizationsAzure = ({ setStepValidated, architecture, composeID 
           </Popover>
         }
       >
-        <RegionsSelect provider={AZURE_PROVIDER} currentRegion={wizardContext.chosenRegion} onChange={onRegionChange} composeID={composeID} />
+        <RegionsSelect provider={AZURE_PROVIDER} currentRegion={wizardContext.chosenRegion} onChange={onRegionChange} composeID={image.id} />
       </FormGroup>
       <FormGroup
         label="Select instance size"
@@ -99,7 +101,7 @@ const AccountCustomizationsAzure = ({ setStepValidated, architecture, composeID 
         }
       >
         <InstanceTypesSelect
-          architecture={architecture}
+          architecture={image.architecture}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -135,8 +137,7 @@ const AccountCustomizationsAzure = ({ setStepValidated, architecture, composeID 
 };
 
 AccountCustomizationsAzure.propTypes = {
-  architecture: PropTypes.string.isRequired,
-  composeID: PropTypes.string.isRequired,
   setStepValidated: PropTypes.func.isRequired,
+  image: imageProps,
 };
 export default AccountCustomizationsAzure;

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
@@ -4,13 +4,14 @@ import { Form, FormGroup, Popover, Title, Text, Button } from '@patternfly/react
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 import { GCP_PROVIDER } from '../../../../constants';
+import { imageProps } from '../../helpers';
 import SourcesSelect from '../../../SourcesSelect';
 import InstanceCounter from '../../../InstanceCounter';
 import InstanceTypesSelect from '../../../InstanceTypesSelect';
 import RegionsSelect from '../../../RegionsSelect';
 import { useWizardContext } from '../../../Common/WizardContext';
 
-const AccountCustomizationsGCP = ({ setStepValidated, architecture, composeID }) => {
+const AccountCustomizationsGCP = ({ setStepValidated, image }) => {
   const [wizardContext, setWizardContext] = useWizardContext();
   const [validations, setValidation] = React.useState({
     sources: wizardContext.chosenSource ? 'success' : 'default',
@@ -47,6 +48,7 @@ const AccountCustomizationsGCP = ({ setStepValidated, architecture, composeID })
         fieldId="gcp-select-source"
       >
         <SourcesSelect
+          image={image}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -75,7 +77,7 @@ const AccountCustomizationsGCP = ({ setStepValidated, architecture, composeID })
           </Popover>
         }
       >
-        <RegionsSelect provider={GCP_PROVIDER} onChange={onRegionChange} composeID={composeID} currentRegion={wizardContext.chosenRegion} />
+        <RegionsSelect provider={GCP_PROVIDER} onChange={onRegionChange} composeID={image.id} currentRegion={wizardContext.chosenRegion} />
       </FormGroup>
       <FormGroup
         label="Select machine type"
@@ -99,7 +101,7 @@ const AccountCustomizationsGCP = ({ setStepValidated, architecture, composeID })
         }
       >
         <InstanceTypesSelect
-          architecture={architecture}
+          architecture={image.architecture}
           setValidation={(validation) =>
             setValidation((prevValidations) => ({
               ...prevValidations,
@@ -135,8 +137,7 @@ const AccountCustomizationsGCP = ({ setStepValidated, architecture, composeID })
 };
 
 AccountCustomizationsGCP.propTypes = {
-  architecture: PropTypes.string.isRequired,
-  composeID: PropTypes.string.isRequired,
   setStepValidated: PropTypes.func.isRequired,
+  image: imageProps,
 };
 export default AccountCustomizationsGCP;

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/index.js
@@ -1,14 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../Common/constants';
+import { imageProps } from '../../helpers';
 import { defaultRegionByProvider } from '../../../Common/helpers';
 import { useWizardContext } from '../../../Common/WizardContext';
 import AWS from './aws';
 import GCP from './gcp';
 import Azure from './azure';
 
-const AccountCustomizations = ({ setStepValidated, architecture, composeID, provider, imageSourceID }) => {
+const AccountCustomizations = ({ setStepValidated, image }) => {
   const [, setWizardContext] = useWizardContext();
+  const provider = image.provider;
 
   React.useEffect(() => {
     provider &&
@@ -16,17 +18,17 @@ const AccountCustomizations = ({ setStepValidated, architecture, composeID, prov
         ...prevState,
         provider,
         chosenRegion: defaultRegionByProvider(provider),
-        chosenImageID: composeID,
+        chosenImageID: image.id,
       }));
   }, [provider, setWizardContext]);
 
   switch (provider) {
     case AWS_PROVIDER:
-      return <AWS setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} imageSourceID={imageSourceID} />;
+      return <AWS setStepValidated={setStepValidated} image={image} />;
     case AZURE_PROVIDER:
-      return <Azure setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} />;
+      return <Azure setStepValidated={setStepValidated} image={image} />;
     case GCP_PROVIDER:
-      return <GCP setStepValidated={setStepValidated} architecture={architecture} composeID={composeID} />;
+      return <GCP setStepValidated={setStepValidated} image={image} />;
     default:
       throw new Error(`Can not render AccountCustomizations for unrecognized provider: ${provider}`);
   }
@@ -34,10 +36,7 @@ const AccountCustomizations = ({ setStepValidated, architecture, composeID, prov
 
 AccountCustomizations.propTypes = {
   setStepValidated: PropTypes.func.isRequired,
-  architecture: PropTypes.string.isRequired,
-  composeID: PropTypes.string.isRequired,
-  provider: PropTypes.oneOf([AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER]),
-  imageSourceID: PropTypes.string,
+  image: imageProps,
 };
 
 export default AccountCustomizations;

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -7,7 +7,7 @@ import RegionsSelect from '../../../RegionsSelect';
 import { imageProps } from '../../helpers.js';
 
 const DirectProviderLink = ({ image }) => {
-  // TODO
+  // TODO gcp
   const uploadStatus = image.uploadStatus || { options: {} };
   const uploadOptions = image.uploadOptions || {};
   const [currentImage, setImage] = React.useState({ imageID: image.id, ...uploadStatus.options });

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SourceMissing from '.';
 
 import { render, screen } from '../../../../mocks/utils';
+import { awsImage, azureImage } from '../../../../mocks/fixtures/image.fixtures';
 
 describe('Source missing', () => {
   describe('Loading state', () => {
@@ -13,57 +14,57 @@ describe('Source missing', () => {
   });
 
   describe('AWS', () => {
-    const awsImage = {
-      provider: 'aws',
+    const image = {
+      ...awsImage,
       uploadStatus: {
         options: { region: 'us-east-1', ami: 'ami-123123' },
       },
     };
 
     test('has create source button', () => {
-      render(<SourceMissing image={awsImage} />);
+      render(<SourceMissing image={image} />);
 
       const sourcesLink = screen.getByRole('link', { name: 'Create Source' });
       expect(sourcesLink).toHaveAttribute('href', '/settings/sources/new');
     });
 
     test('renders direct link', () => {
-      render(<SourceMissing image={awsImage} />);
+      render(<SourceMissing image={image} />);
 
       const directLink = screen.getByRole('link', { name: 'Launch with AWS console' });
       expect(directLink).toHaveAttribute(
         'href',
-        `https://console.aws.amazon.com/ec2/v2/home?region=${awsImage.uploadStatus.options.region}#LaunchInstanceWizard:ami=${awsImage.uploadStatus.options.ami}`
+        `https://console.aws.amazon.com/ec2/v2/home?region=${image.uploadStatus.options.region}#LaunchInstanceWizard:ami=${image.uploadStatus.options.ami}`
       );
     });
   });
 
   describe('Azure', () => {
-    const azureImage = {
-      provider: 'azure',
+    const image = {
+      ...azureImage,
       uploadStatus: { options: { image_name: 'cool-image' } },
       uploadOptions: { tenant_id: '123', subscription_id: '321', resource_group: 'testGroup' },
     };
 
     test('has create source button', () => {
-      render(<SourceMissing image={azureImage} />);
+      render(<SourceMissing image={image} />);
 
       const sourcesLink = screen.getByRole('link', { name: 'Create Source' });
       expect(sourcesLink).toHaveAttribute('href', '/settings/sources/new');
     });
 
     test('renders direct link', () => {
-      render(<SourceMissing image={azureImage} />);
+      render(<SourceMissing image={image} />);
 
       const url =
         'https://portal.azure.com/#@' +
-        azureImage.uploadOptions.tenant_id +
+        image.uploadOptions.tenant_id +
         '/resource/subscriptions/' +
-        azureImage.uploadOptions.subscription_id +
+        image.uploadOptions.subscription_id +
         '/resourceGroups/' +
-        azureImage.uploadOptions.resource_group +
+        image.uploadOptions.resource_group +
         '/providers/Microsoft.Compute/images/' +
-        azureImage.uploadStatus.options.image_name;
+        image.uploadStatus.options.image_name;
 
       const directLink = screen.getByRole('link', { name: 'View uploaded image' });
       expect(directLink).toHaveAttribute('href', url);

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -23,28 +23,16 @@ const missingSource = ({ image, isLoading, sourcesError }) => [
   },
 ];
 
-const wizardSteps = ({
-  stepIdReached,
-  image: { name, id, architecture, provider, sourceIDs },
-  stepValidation,
-  setStepValidation,
-  setLaunchSuccess,
-}) => [
+const wizardSteps = ({ stepIdReached, image, stepValidation, setStepValidation, setLaunchSuccess }) => [
   {
     name: 'Account and customization',
     steps: [
       {
-        name: humanizeProvider(provider),
+        name: humanizeProvider(image.provider),
         id: 1,
         enableNext: stepValidation.awsStep,
         component: (
-          <AccountCustomizations
-            provider={provider}
-            architecture={architecture || 'x86_64'}
-            composeID={id}
-            imageSourceID={sourceIDs?.[0]}
-            setStepValidated={(validated) => setStepValidation((prev) => ({ ...prev, awsStep: validated }))}
-          />
+          <AccountCustomizations image={image} setStepValidated={(validated) => setStepValidation((prev) => ({ ...prev, awsStep: validated }))} />
         ),
         canJumpTo: stepIdReached >= 1,
       },
@@ -60,14 +48,14 @@ const wizardSteps = ({
   {
     name: 'Review details',
     id: 5,
-    component: <ReviewDetails imageName={name} />,
+    component: <ReviewDetails imageName={image.name} />,
     canJumpTo: stepIdReached >= 5,
     nextButtonText: 'Launch',
   },
   {
     name: 'Finish Progress',
     id: 6,
-    component: <FinishStep setLaunchSuccess={() => setLaunchSuccess(true)} imageID={id} />,
+    component: <FinishStep setLaunchSuccess={() => setLaunchSuccess(true)} imageID={image.id} />,
     isFinishedStep: true,
   },
 ];

--- a/src/Components/SourcesSelect/SourcesSelect.test.js
+++ b/src/Components/SourcesSelect/SourcesSelect.test.js
@@ -2,28 +2,43 @@ import React from 'react';
 import SourcesSelect from '.';
 import userEvent from '@testing-library/user-event';
 import { sourcesList } from '../../mocks/fixtures/sources.fixtures';
+import { awsImage, gcpImage } from '../../mocks/fixtures/image.fixtures';
 import { render, screen } from '../../mocks/utils';
 
-const mockContext = require('../Common/WizardContext/initialState');
-
 describe('SourcesSelect', () => {
-  test('preselect aws source', async () => {
-    render(<SourcesSelect imageSourceID={1} setValidation={jest.fn()} />);
-    // wizard context mock is `{chosenSource: 1}`
-    const selectDropdown = await screen.findByText('Source 1');
+  test('no source preselected when multiple available', async () => {
+    render(<SourcesSelect image={{ ...awsImage, sourceIDs: ['1', '2'] }} setValidation={jest.fn()} />);
+    const selectDropdown = await screen.findByText('Select account');
     await userEvent.click(selectDropdown);
+
+    const items = await screen.findAllByLabelText('Source account');
+    expect(items).toHaveLength(sourcesList.length);
   });
 
-  test('preselects the chosen source', async () => {
-    jest.mock('../Common/WizardContext/initialState', () => ({
-      __esModule: true,
-      default: { ...mockContext, provider: 'gcp' },
-    }));
-    render(<SourcesSelect setValidation={jest.fn()} />);
+  test('filters and preselect single available source', async () => {
+    render(<SourcesSelect image={{ ...awsImage, sourceIDs: ['2'] }} setValidation={jest.fn()} />);
+    const selectDropdown = await screen.findByText('Source 2');
+    await userEvent.click(selectDropdown);
+
+    const items = await screen.findAllByLabelText('Source account');
+    expect(items).toHaveLength(1);
+  });
+
+  test('preselect aws source', async () => {
+    render(<SourcesSelect image={{ ...awsImage, sourceIDs: ['1', '2'] }} setValidation={jest.fn()} />, { contextValues: { chosenSource: '1' } });
     const selectDropdown = await screen.findByText('Source 1');
     await userEvent.click(selectDropdown);
 
     const items = await screen.findAllByLabelText('Source account');
     expect(items).toHaveLength(sourcesList.length);
+  });
+
+  test('preselects gcp source', async () => {
+    render(<SourcesSelect image={{ ...gcpImage, sourceIDs: ['10'] }} setValidation={jest.fn()} />, { provider: 'gcp' });
+    const selectDropdown = await screen.findByText('GCP Source 1');
+    await userEvent.click(selectDropdown);
+
+    const items = await screen.findAllByLabelText('Source account');
+    expect(items).toHaveLength(1);
   });
 });

--- a/src/Components/SourcesSelect/index.js
+++ b/src/Components/SourcesSelect/index.js
@@ -1,14 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert, Select, SelectOption, Spinner } from '@patternfly/react-core';
-import { useQuery } from 'react-query';
-import { sourcesQueryKey } from '../../API/queryKeys';
-import { fetchSourcesList } from '../../API';
-import { useWizardContext } from '../Common/WizardContext';
-import { IB_SOURCE_PROVIDERS } from '../Common/constants';
 
-const SourcesSelect = ({ setValidation, imageSourceID }) => {
-  const [{ provider, chosenSource }, setWizardContext] = useWizardContext();
+import { imageProps } from '../ProvisioningWizard/helpers';
+import { useSourcesForImage } from '../Common/Hooks/sources';
+import { useWizardContext } from '../Common/WizardContext';
+
+const SourcesSelect = ({ setValidation, image }) => {
+  const [{ chosenSource }, setWizardContext] = useWizardContext();
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(null);
   const selectObject = (id, name) => ({
@@ -16,26 +15,18 @@ const SourcesSelect = ({ setValidation, imageSourceID }) => {
     toString: () => name,
     compareTo: (other) => other.id === id,
   });
-  const {
-    error,
-    isLoading,
-    data: sources,
-  } = useQuery(sourcesQueryKey(provider), () => fetchSourcesList(provider), {
-    enabled: !!provider,
-    onSuccess: (data) => {
-      const id = chosenSource;
-
-      if (IB_SOURCE_PROVIDERS.includes(provider) && imageSourceID) {
-        setSelected(selectObject(imageSourceID, data.find((source) => source.id === imageSourceID).name));
+  const { isLoading, error, sources } = useSourcesForImage(image, {
+    onSuccess: (sources) => {
+      if (chosenSource) {
+        setSelected(selectObject(chosenSource, sources.find((source) => source.id === chosenSource).name));
+        setValidation('success');
+      } else if (sources.length === 1) {
+        setSelected(selectObject(sources[0].id, sources[0].name));
         setWizardContext((prevState) => ({
           ...prevState,
-          chosenSource: imageSourceID,
+          chosenSource: sources[0].id,
         }));
         setValidation('success');
-      } else if (!id) {
-        return;
-      } else {
-        setSelected(selectObject(id, data.find((source) => source.id === id).name));
       }
     },
   });
@@ -79,7 +70,8 @@ const SourcesSelect = ({ setValidation, imageSourceID }) => {
       isOpen={isOpen}
       onToggle={(openState) => setIsOpen(openState)}
       selections={selected}
-      isDisabled={!!imageSourceID}
+      // TODO decide if to disable the select
+      // isDisabled={sources?.length === 1}
       onSelect={onSelect}
       placeholderText="Select account"
       aria-label="Select account"
@@ -91,7 +83,7 @@ const SourcesSelect = ({ setValidation, imageSourceID }) => {
 
 SourcesSelect.propTypes = {
   setValidation: PropTypes.func.isRequired,
-  imageSourceID: PropTypes.string,
+  image: imageProps,
 };
 
 export default SourcesSelect;

--- a/src/Components/TemplateSelect/TemplateSelect.test.js
+++ b/src/Components/TemplateSelect/TemplateSelect.test.js
@@ -6,7 +6,7 @@ import { templates } from '../../mocks/fixtures/templates.fixtures';
 
 describe('TemplateSelect', () => {
   test('get all templates options', async () => {
-    render(<TemplateSelect />);
+    render(<TemplateSelect />, { provider: 'aws', contextValues: { chosenSource: '1' } });
     const selectDropdown = await screen.findByLabelText('Select templates');
     await userEvent.click(selectDropdown);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,3 @@
 export const AWS_PROVIDER = 'aws';
 export const AZURE_PROVIDER = 'azure';
 export const GCP_PROVIDER = 'gcp';
-export const IB_SOURCE_PROVIDERS = [AWS_PROVIDER];

--- a/src/mocks/fixtures/image.fixtures.js
+++ b/src/mocks/fixtures/image.fixtures.js
@@ -1,3 +1,24 @@
+export const awsImage = {
+  provider: 'aws',
+  id: '1197ba12-bcb6-4fbe-a77a-823a75519811',
+  name: 'AWS Image',
+  architecture: 'x86_64',
+};
+
+export const azureImage = {
+  provider: 'azure',
+  id: '6697ba12-bcb6-4fbe-a77a-823a75519811',
+  name: 'Azure Image',
+  architecture: 'x86_64',
+};
+
+export const gcpImage = {
+  provider: 'gcp',
+  id: '3397ba12-bcb6-4fbe-a77a-823a75519811',
+  name: 'GCP Image',
+  architecture: 'x86_64',
+};
+
 export const parentImage = { region: 'us-east-1', id: '0097ba12-bcb6-4fbe-a77a-823a75519811' };
 
 export const clonedImages = {

--- a/src/mocks/fixtures/sources.fixtures.js
+++ b/src/mocks/fixtures/sources.fixtures.js
@@ -1,7 +1,20 @@
 export const sourcesList = [
   {
     name: 'Source 1',
-    id: 1,
+    id: '1',
   },
-  { name: 'Source 2', id: 2 },
+  { name: 'Source 2', id: '2' },
 ];
+
+export const gcpSourcesList = [
+  {
+    name: 'GCP Source 1',
+    id: '10',
+  },
+];
+
+export const awsSourceUploadInfo = (account_id = '123456789') => {
+  {
+    account_id;
+  }
+};

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { imageBuilderURL, provisioningUrl } from '../API/helpers';
 import { awsInstanceTypeList, azureInstanceTypeList } from './fixtures/instanceTypes.fixtures';
-import { sourcesList } from './fixtures/sources.fixtures';
+import { sourcesList, gcpSourcesList, awsSourceUploadInfo } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
 import { clonedImages, parentImage, successfulCloneStatus } from './fixtures/image.fixtures';
 import { AWSReservation, getAzureReservation, createdAWSReservation, createdAzureReservation, reservation } from './fixtures/reservation.fixtures';
@@ -9,7 +9,21 @@ import { templates } from './fixtures/templates.fixtures';
 
 export const handlers = [
   rest.get(provisioningUrl('sources'), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(sourcesList));
+    const provider = req.url.searchParams.get('provider');
+    if (provider === 'aws') {
+      return res(ctx.status(200), ctx.json(sourcesList));
+    } else if (provider === 'gcp') {
+      return res(ctx.status(200), ctx.json(gcpSourcesList));
+    }
+  }),
+  rest.get(provisioningUrl('sources/:sourceID/upload_info'), (req, res, ctx) => {
+    const { sourceID } = req.params;
+    if (sourceID === '1' || sourceID === '2') {
+      return res(ctx.status(200), ctx.json(awsSourceUploadInfo()));
+    } else if (sourceID === '10') {
+      // GCP upload info not defined yet
+      return res(ctx.status(200), ctx.json({}));
+    }
   }),
   rest.get(provisioningUrl('pubkeys'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(pubkeysList));

--- a/src/mocks/utils.js
+++ b/src/mocks/utils.js
@@ -5,18 +5,18 @@ import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { WizardProvider } from '../Components/Common/WizardContext';
 
-const AllProviders = ({ children, provider }) => {
+const AllProviders = ({ children, provider, ...contextValues }) => {
   const queryClient = new QueryClient();
 
   return (
-    <WizardProvider provider={provider}>
+    <WizardProvider provider={provider} {...contextValues}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </WizardProvider>
   );
 };
 
 const customRender = (ui, options = {}) =>
-  render(ui, { wrapper: (props) => <AllProviders provider={options.provider || 'aws'} {...props} />, ...options });
+  render(ui, { wrapper: (props) => <AllProviders provider={options.provider || 'aws'} {...props} {...options.contextValues} />, ...options });
 
 export * from '@testing-library/react';
 


### PR DESCRIPTION
This improves how we fetch usable sources.
Uses the filtered sources for the Sources select.
Drops notion of Shared with source in the select.
Insted preselects the source when only single is available to use.

Fixes HMS-1625

This goes above what we have implemented in #238 and uses the same approach for the sources select.
IMO much supperior approach as Users can select only sources that are usable to launch the given image.
IMO this is a great UX improvemet :)

On top of implemented changes, I've changed tests, so test itself is able to set the context values directly.