### PR TITLE
fix: sources loading when one source failing

### DIFF
--- a/src/Components/Common/Hooks/sources.js
+++ b/src/Components/Common/Hooks/sources.js
@@ -1,19 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import { useQuery, useQueries } from 'react-query';
 
 import { SOURCES_QUERY_KEY, SOURCE_UPLOAD_INFO_KEY } from '../../../API/queryKeys';
 import { fetchSourcesList, fetchSourceUploadInfo } from '../../../API';
 import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../constants';
-
-export const imageProps = PropTypes.shape({
-  name: PropTypes.string,
-  id: PropTypes.string,
-  provider: PropTypes.string,
-  architecture: PropTypes.string,
-  sourceIDs: PropTypes.arrayOf(PropTypes.string),
-  accountIDs: PropTypes.arrayOf(PropTypes.string),
-}).isRequired;
 
 export const useSourcesData = (provider, { refetch = false } = {}) => {
   const {
@@ -36,7 +26,7 @@ const useSourcesUploadInfos = (provider, { refetch }) => {
 
   const isLoading = isLoadingSources || uploadInfos.some((info) => info.isLoading);
   const infos = [];
-  !isLoading &&
+  !isLoadingSources &&
     sources?.forEach((source, i) => {
       uploadInfos[i].isSuccess && infos.push({ ...uploadInfos[i].data, ...source });
     });
@@ -57,13 +47,13 @@ const providerSourceFilter = (image) => {
 
 export const useSourcesForImage = (image, { refetch = false, onSuccess = () => {} } = {}) => {
   const { isLoading, error, infos } = useSourcesUploadInfos(image.provider, { refetch });
+  const filteredSources = image.isTesting ? infos : infos?.filter(providerSourceFilter(image));
 
   React.useEffect(() => {
     if (!isLoading && !error) {
       onSuccess(filteredSources);
     }
-  }, [isLoading, error]);
+  }, [isLoading]);
 
-  const filteredSources = image.isTesting ? infos : infos?.filter(providerSourceFilter(image));
   return { isLoading, error, sources: filteredSources || [] };
 };

--- a/src/Components/ProvisioningWizard/ProvisioningWizard.test.js
+++ b/src/Components/ProvisioningWizard/ProvisioningWizard.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { render, screen } from '../../mocks/utils';
+import { imageBuilderURL, provisioningUrl } from '../../API/helpers';
+
+import ProvisioningWizard from '.';
+
+import { awsImage } from '../../mocks/fixtures/image.fixtures';
+import { awsSourceFailedUploadInfo, awsSourceUploadInfo } from '../../mocks/fixtures/sources.fixtures';
+
+describe('ProvisioningWizard', () => {
+  beforeEach(() => {
+    const { server, rest } = window.msw;
+    // no clones
+    server.use(
+      rest.get(imageBuilderURL(`composes/${awsImage.id}/clones`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json({ data: [], meta: { count: 0 } }));
+      })
+    );
+  });
+
+  describe('Available source validation', () => {
+    test('handles unreachable - invalid - source gracefuly', async () => {
+      const { server, rest } = window.msw;
+
+      server.use(
+        rest.get(provisioningUrl('sources/:sourceID/upload_info'), (req, res, ctx) => {
+          const { sourceID } = req.params;
+          if (sourceID === '1') {
+            return res(ctx.status(200), ctx.json(awsSourceUploadInfo()));
+          } else if (sourceID === '2') {
+            return res(ctx.status(500), ctx.json(awsSourceFailedUploadInfo));
+          }
+        })
+      );
+
+      render(<ProvisioningWizard image={{ ...awsImage, sourceIDs: ['1'] }} />);
+      // wait for the sources to load
+      await screen.findByText('Launch image AWS image', { exact: false });
+
+      const sourceDropdown = await screen.findByText('Source 1');
+      expect(sourceDropdown).toBeInTheDocument();
+
+      expect(await screen.queryByText(/Loading available Sources/i)).not.toBeInTheDocument();
+    });
+
+    test('shows loading sources', () => {
+      render(<ProvisioningWizard image={awsImage} />);
+      expect(screen.getByText(/Loading available Sources/i)).toBeInTheDocument();
+    });
+
+    test('shows empty state when no sources matching', async () => {
+      // the image has no source info, thus no match
+      render(<ProvisioningWizard image={awsImage} />);
+      const createBtn = await screen.findByText('Create Source');
+
+      expect(createBtn).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Form, FormGroup, Popover, Title, Text, Button } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import { HelpIcon } from '@patternfly/react-icons';
 import { useFlag } from '@unleash/proxy-client-react';
 
 import { AWS_PROVIDER } from '../../../../constants';

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Form, FormGroup, Popover, Title, Text, Button } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import { AZURE_PROVIDER } from '../../../../constants';
 import { imageProps } from '../../helpers';

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Form, FormGroup, Popover, Title, Text, Button } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import { GCP_PROVIDER } from '../../../../constants';
 import { imageProps } from '../../helpers';

--- a/src/Components/ProvisioningWizard/steps/index.js
+++ b/src/Components/ProvisioningWizard/steps/index.js
@@ -60,6 +60,6 @@ const wizardSteps = ({ stepIdReached, image, stepValidation, setStepValidation, 
   },
 ];
 
-const steps = (props) => (!props.isLoading && props.availableSources.length > 0 ? wizardSteps(props) : missingSource(props));
+const steps = (props) => (props.availableSources.length > 0 ? wizardSteps(props) : missingSource(props));
 
 export default steps;

--- a/src/mocks/fixtures/sources.fixtures.js
+++ b/src/mocks/fixtures/sources.fixtures.js
@@ -13,8 +13,13 @@ export const gcpSourcesList = [
   },
 ];
 
-export const awsSourceUploadInfo = (account_id = '123456789') => {
-  {
-    account_id;
-  }
-};
+export const awsSourceUploadInfo = (account_id = '123456789') => ({ aws: { account_id } });
+
+export const awsSourceFailedUploadInfo = () => ({
+  msg: 'AWS API error: unable to get AWS upload info',
+  trace_id: 'trcid',
+  error:
+    'unable to initialize AWS client: cannot assume role operation error STS: AssumeRole, https response error StatusCode: 400, RequestID: <AWSRID>, api error ValidationError: arn:aws:iam:asdfasdf/doesntwork is invalid',
+  version: '32b1201',
+  build_time: '2023-04-26_11:14:00',
+});

--- a/src/mocks/utils.js
+++ b/src/mocks/utils.js
@@ -2,10 +2,16 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
 import { WizardProvider } from '../Components/Common/WizardContext';
 
 const AllProviders = ({ children, provider, ...contextValues }) => {
+  setLogger({
+    log: console.log,
+    warn: console.warn,
+    // ✅ no more errors on the console
+    error: () => {},
+  });
   const queryClient = new QueryClient();
 
   return (


### PR DESCRIPTION
Mainly simplifies the step decision, so we dont flip rendered wizard steps there and back.

Adds tests for the form itself, for now only tests the loading and empty state. Fixes import of the icons.

Fixes HMS-1657