### PR TITLE
fix(HMS-1748): use staleTime config for preventing multiple requests

### DIFF
--- a/src/Components/Common/Query/index.js
+++ b/src/Components/Common/Query/index.js
@@ -3,7 +3,13 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5000,
+    },
+  },
+});
 
 const APIProvider = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 

--- a/src/Components/InstanceTypesSelect/index.js
+++ b/src/Components/InstanceTypesSelect/index.js
@@ -20,6 +20,7 @@ const InstanceTypesSelect = ({ setValidation, architecture }) => {
     error,
     data: instanceTypes,
   } = useQuery(['instanceTypes', chosenRegion], () => fetchInstanceTypesList(chosenRegion, provider), {
+    staleTime: 5 * (60 * 1000), // data is considered fresh for 5 minutes (same as cacheTime)
     select: (types) => types.filter((type) => type.architecture === architecture),
     enabled: !!chosenRegion && !!chosenSource,
   });

--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
@@ -92,6 +92,7 @@ const ReservationProgress = ({ setLaunchSuccess }) => {
   // polling request
   const { data: polledReservation } = useQuery(['reservation', reservationID], () => fetchReservation(reservationID), {
     enabled: !!reservationID && currentStep < steps.length && !currentError,
+    staleTime: 0, // disable cache
     refetchInterval: (data) => {
       if (data?.success || !!data?.error) return false;
       return currentInterval;


### PR DESCRIPTION
Requests from client side are triggered multiple times due to missing configuration in react-query , data becomes stale as soon as it fetched, for further configuarion defaults of react-query - https://tanstack.com/query/v4/docs/react/guides/important-defaults 

This PR adds a global `staleTime` of 10 seconds, which is still aggresive policy,  but cancel it during resevation polling.

 I recored the amount of requests during  wizard steps progress before polling:

before:

https://user-images.githubusercontent.com/11807069/236284179-6f4f56ed-66f9-4908-87f3-ffbda47e7d5e.mov

after:

https://user-images.githubusercontent.com/11807069/236284230-7aa9f1cd-35bb-44af-9af4-3928140538dd.mov

More about `staleTime`, this [post](https://www.codemzy.com/blog/react-query-cachetime-staletime) covers it well


