### PR TITLE
Fix region select disabled in AWS provisioning wizard

### DIFF
--- a/src/Components/RegionsSelect/RegionsSelect.test.js
+++ b/src/Components/RegionsSelect/RegionsSelect.test.js
@@ -26,19 +26,6 @@ describe('RegionSelect', () => {
     const filteredRegion = screen.queryByText(clonedImages.data[0].request.region);
     expect(filteredRegion).not.toBeInTheDocument();
   });
-
-  test('no clones images', async () => {
-    const { server, rest } = window.msw;
-
-    server.use(
-      rest.get(imageBuilderURL(`composes/${parentImage.id}/clones`), (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json({ data: [] }));
-      })
-    );
-    await mountSelectAndClick();
-    const select = await screen.findByLabelText('Options menu');
-    expect(select).toBeDisabled();
-  });
 });
 
 const mountSelectAndClick = async () => {

--- a/src/Components/RegionsSelect/index.js
+++ b/src/Components/RegionsSelect/index.js
@@ -71,7 +71,6 @@ const RegionsSelect = ({ provider, currentRegion, composeID, onChange }) => {
       selections={currentRegion}
       onToggle={onToggle}
       onSelect={onSelect}
-      isDisabled={(clonedImages?.length || 0) <= 1}
     >
       {images.map(({ id, region }) => (
         <SelectOption aria-label="Region item" key={id} value={region} />


### PR DESCRIPTION
If an AWS in image-builder has been cloned to one other region, then the region select dropdown is disabled in theprovisioning wizard, and the user can't select the 2nd region. This is only an issue when the image has been cloned only once; if the image is shared to a third region, then the dropdown is enabled.

This PR fixes that issue so that the dropdown is always enabled.