### PR TITLE
fix(HMS-1917): Add source filtering for GCP

### DIFF
--- a/src/Components/Common/Hooks/sources.js
+++ b/src/Components/Common/Hooks/sources.js
@@ -3,7 +3,7 @@ import { useQuery, useQueries } from 'react-query';
 
 import { SOURCES_QUERY_KEY, SOURCE_UPLOAD_INFO_KEY } from '../../../API/queryKeys';
 import { fetchSourcesList, fetchSourceUploadInfo } from '../../../API';
-import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../constants';
 
 export const useSourcesData = (provider, { refetch = false } = {}) => {
   const {
@@ -40,6 +40,8 @@ const providerSourceFilter = (image) => {
       return (info) => image.sourceIDs?.includes(info.id) || image.accountIDs?.includes(info.aws.account_id);
     case AZURE_PROVIDER:
       return (info) => image.uploadOptions?.source_id === info.id || info.azure?.subscription_id === image.uploadOptions?.subscription_id;
+    case GCP_PROVIDER:
+      return () => true;
     default:
       return (info) => image.sourceIDs?.includes(info.id);
   }
@@ -48,7 +50,6 @@ const providerSourceFilter = (image) => {
 export const useSourcesForImage = (image, { refetch = false, onSuccess = () => {} } = {}) => {
   const { isLoading, error, infos } = useSourcesUploadInfos(image.provider, { refetch });
   const filteredSources = image.isTesting ? infos : infos?.filter(providerSourceFilter(image));
-
   React.useEffect(() => {
     if (!isLoading && !error) {
       onSuccess(filteredSources);

--- a/src/Components/InstancesTable/helpers.js
+++ b/src/Components/InstancesTable/helpers.js
@@ -1,4 +1,4 @@
-import { AWS_PROVIDER, AZURE_PROVIDER } from '../../constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../constants';
 
 export const SSHUsername = (provider) => {
   switch (provider) {
@@ -6,6 +6,8 @@ export const SSHUsername = (provider) => {
       return 'ec2-user';
     case AZURE_PROVIDER:
       return 'azureuser';
+    case GCP_PROVIDER:
+      return 'gcpuser';
     default:
       '';
   }

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Bullseye, Stack, StackItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../../constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../../constants';
 import RegionsSelect from '../../../RegionsSelect';
 import { imageProps } from '../../helpers.js';
 
@@ -29,6 +29,10 @@ const DirectProviderLink = ({ image }) => {
         uploadOptions.resource_group +
         '/providers/Microsoft.Compute/images/' +
         uploadStatus.options.image_name;
+      break;
+    case GCP_PROVIDER:
+      text = 'Launch with Google Cloud console';
+      url = 'https://console.cloud.google.com/welcome';
       break;
     default:
       throw new Error(`Steps requested for unknown provider: ${image.provider}`);

--- a/src/Components/SourcesSelect/SourcesSelect.test.js
+++ b/src/Components/SourcesSelect/SourcesSelect.test.js
@@ -33,8 +33,10 @@ describe('SourcesSelect', () => {
     expect(items).toHaveLength(sourcesList.length);
   });
 
-  test('preselects gcp source', async () => {
-    render(<SourcesSelect image={{ ...gcpImage, sourceIDs: ['10'] }} setValidation={jest.fn()} />, { provider: 'gcp' });
+  test('gcp source verifying email', async () => {
+    render(<SourcesSelect image={{ ...gcpImage, accountIDs: ['serviceAccount:example@redhat.com'] }} setValidation={jest.fn()} />, {
+      provider: 'gcp',
+    });
     const selectDropdown = await screen.findByText('GCP Source 1');
     await userEvent.click(selectDropdown);
 

--- a/src/mocks/fixtures/sources.fixtures.js
+++ b/src/mocks/fixtures/sources.fixtures.js
@@ -13,6 +13,8 @@ export const gcpSourcesList = [
   },
 ];
 
+export const gcpSourceUploadInfo = (service_account_principal = 'serviceAccount:example@redhat.com') => ({ gcp: { service_account_principal } });
+
 export const awsSourceUploadInfo = (account_id = '123456789') => ({ aws: { account_id } });
 
 export const awsSourceFailedUploadInfo = () => ({

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { imageBuilderURL, provisioningUrl } from '../API/helpers';
 import { awsInstanceTypeList, azureInstanceTypeList } from './fixtures/instanceTypes.fixtures';
-import { sourcesList, gcpSourcesList, awsSourceUploadInfo } from './fixtures/sources.fixtures';
+import { sourcesList, gcpSourcesList, awsSourceUploadInfo, gcpSourceUploadInfo } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
 import { clonedImages, parentImage, successfulCloneStatus } from './fixtures/image.fixtures';
 import { AWSReservation, getAzureReservation, createdAWSReservation, createdAzureReservation, reservation } from './fixtures/reservation.fixtures';
@@ -21,8 +21,7 @@ export const handlers = [
     if (sourceID === '1' || sourceID === '2') {
       return res(ctx.status(200), ctx.json(awsSourceUploadInfo()));
     } else if (sourceID === '10') {
-      // GCP upload info not defined yet
-      return res(ctx.status(200), ctx.json({}));
+      return res(ctx.status(200), ctx.json(gcpSourceUploadInfo()));
     }
   }),
   rest.get(provisioningUrl('pubkeys'), (req, res, ctx) => {


### PR DESCRIPTION
Depends on https://github.com/RHEnVision/provisioning-backend/pull/571
- A function for filtering GCP sources was missing so I added it.
- a general link for GCP was added as well, it needs to be refactored to direct the customer to his specific project, I opened a bug for it. 
- Instances table will be added next
For now, we are relying on getting from the backend the email that the image was shared with. 