### PR TITLE
feat(HMS-1879): Add instance desc table for GCP

### DIFF
--- a/src/Components/Common/instanceHelpers.js
+++ b/src/Components/Common/instanceHelpers.js
@@ -1,4 +1,4 @@
-import { AWS_PROVIDER, AZURE_PROVIDER } from './constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from './constants';
 
 export const instanceLink = (instanceID, provider, region) => {
   switch (provider) {
@@ -6,6 +6,8 @@ export const instanceLink = (instanceID, provider, region) => {
       return `https://console.aws.amazon.com/ec2/home?region=${region}#InstanceDetails:instanceId=${instanceID}`;
     case AZURE_PROVIDER:
       return `https://portal.azure.com/#@rhdevcloudops.onmicrosoft.com/resource${instanceID}/overview`;
+    case GCP_PROVIDER:
+      return `https://console.cloud.google.com/compute/instancesDetail/zones/${region}/instances/${instanceID}`;
     default:
       return null;
   }

--- a/src/Components/InstancesTable/helpers.js
+++ b/src/Components/InstancesTable/helpers.js
@@ -7,7 +7,7 @@ export const SSHUsername = (provider) => {
     case AZURE_PROVIDER:
       return 'azureuser';
     case GCP_PROVIDER:
-      return 'gcpuser';
+      return 'gcp-user';
     default:
       '';
   }

--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/ReservationProgress.test.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/ReservationProgress.test.js
@@ -9,6 +9,8 @@ import {
   polledReservation,
   successfulReservation,
   successfulAzureReservation,
+  successfulGCPReservation,
+  GCPReservation,
 } from '../../../../mocks/fixtures/reservation.fixtures';
 import { render, screen, getByRole } from '../../../../mocks/utils';
 import * as constants from './constants';
@@ -70,7 +72,7 @@ describe('Reservation polling', () => {
 
     test('Azure instance table', async () => {
       const { server, rest } = window.msw;
-      mountProgressBar('azure');
+      mountProgressBar('azure', 'eastus');
 
       server.use(
         rest.get(provisioningUrl(`reservations/:id`), (req, res, ctx) => {
@@ -100,6 +102,37 @@ describe('Reservation polling', () => {
     });
   });
 
+  test('GCP instance table', async () => {
+    const { server, rest } = window.msw;
+    mountProgressBar('gcp', 'us-central1-a');
+
+    server.use(
+      rest.get(provisioningUrl(`reservations/:id`), (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(successfulGCPReservation));
+      })
+    );
+    const successText = await screen.findByText('System(s) launched successfully');
+    expect(successText).toBeDefined();
+
+    // show table
+    const instancesIDs = await screen.findAllByLabelText('instance id');
+    const instancesDNSs = await screen.findAllByLabelText('instance dns');
+    const sshCommands = await screen.findAllByLabelText('ssh command');
+    expect(instancesIDs).toHaveLength(GCPReservation.instances.length);
+    expect(instancesDNSs).toHaveLength(GCPReservation.instances.length);
+
+    const instanceLink1 = getByRole(instancesIDs[0], 'link');
+
+    expect(instanceLink1).toHaveTextContent('3003942005876582747');
+    expect(instanceLink1).toHaveAttribute(
+      'href',
+      `https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/3003942005876582747`
+    );
+    expect(getByRole(sshCommands[0], 'textbox')).toHaveValue(`ssh gcp-user@${GCPReservation.instances[0].detail.public_ipv4}`);
+    expect(instancesIDs[1]).toHaveTextContent('3003942005876582748');
+    expect(getByRole(sshCommands[1], 'textbox')).toHaveValue(`ssh gcp-user@${GCPReservation.instances[1].detail.public_ipv4}`);
+  });
+
   test('progress timed out', async () => {
     const TIMEOUT_ERROR_MSG =
       'The launch progress is slower than expected, but we are still on it. It is safe to close this window and check your Amazon cloud console later';
@@ -119,8 +152,11 @@ describe('Reservation polling', () => {
   });
 });
 
-const mountProgressBar = (provider = 'aws') => {
+const mountProgressBar = (provider = 'aws', region = 'us-east-1') => {
   const setLaunchSuccessFunction = jest.fn();
   const imageID = 'image-id';
-  render(<ReservationProgress imageID={imageID} setLaunchSuccess={setLaunchSuccessFunction} />, { provider: provider });
+  render(<ReservationProgress imageID={imageID} setLaunchSuccess={setLaunchSuccessFunction} />, {
+    provider,
+    contextValues: { chosenRegion: region },
+  });
 };

--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/constants.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/constants.js
@@ -1,4 +1,4 @@
-import { AWS_PROVIDER, AZURE_PROVIDER } from '../../../../constants';
+import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../../constants';
 
 export const PF_SUCCESS_100 = '#3E8635';
 export const PF_DANGER_100 = '#C9190B';
@@ -30,4 +30,4 @@ export const GCP_STEPS = [
 
 export const SSH_STEP = [{ name: 'New SSH key', description: 'Creating new SSH public key resource' }];
 
-export const PROVIDERS_INSTANCES_SUPPORT = [AWS_PROVIDER, AZURE_PROVIDER];
+export const PROVIDERS_INSTANCES_SUPPORT = [AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER];

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import SourceMissing from '.';
 
 import { render, screen } from '../../../../mocks/utils';
-import { awsImage, azureImage } from '../../../../mocks/fixtures/image.fixtures';
+import { awsImage, azureImage, gcpImage } from '../../../../mocks/fixtures/image.fixtures';
 
 describe('Source missing', () => {
   describe('Loading state', () => {
@@ -67,6 +67,30 @@ describe('Source missing', () => {
         image.uploadStatus.options.image_name;
 
       const directLink = screen.getByRole('link', { name: 'View uploaded image' });
+      expect(directLink).toHaveAttribute('href', url);
+    });
+  });
+
+  describe('GCP', () => {
+    const image = {
+      ...gcpImage,
+      uploadStatus: { options: { image_name: 'cool-image' } },
+      uploadOptions: { accountIDs: 'example@redhat.com' },
+    };
+
+    test('has create source button', () => {
+      render(<SourceMissing image={image} />);
+
+      const sourcesLink = screen.getByRole('link', { name: 'Create Source' });
+      expect(sourcesLink).toHaveAttribute('href', '/preview/settings/sources/new');
+    });
+
+    test('renders direct link', () => {
+      render(<SourceMissing image={image} />);
+
+      const url = 'https://console.cloud.google.com/welcome';
+
+      const directLink = screen.getByRole('link', { name: 'Launch with Google Cloud console' });
       expect(directLink).toHaveAttribute('href', url);
     });
   });

--- a/src/mocks/fixtures/reservation.fixtures.js
+++ b/src/mocks/fixtures/reservation.fixtures.js
@@ -75,3 +75,33 @@ export const getAzureReservation = {
     },
   ],
 };
+
+export const createdGCPReservation = {
+  reservation_id: 67,
+};
+
+export const successfulGCPReservation = {
+  ...reservationGCP,
+  success: true,
+  step: 1,
+};
+
+export const GCPReservation = {
+  instances: [
+    { instance_id: '3003942005876582747', detail: { public_ipv4: '1.1.1.1' } },
+    { instance_id: '3003942005876582748', detail: { public_ipv4: '2.2.2.2' } },
+  ],
+};
+
+export const reservationGCP = {
+  id: 67,
+  provider: 4,
+  created_at: '2023-06-14T16:03:44.700056Z',
+  steps: 1,
+  step_titles: ['Launch instance(s)'],
+  step: 1,
+  status: 'Launched instance(s)',
+  error: '',
+  finished_at: '2023-06-14T16:04:08.965698Z',
+  success: true,
+};

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -4,7 +4,15 @@ import { awsInstanceTypeList, azureInstanceTypeList } from './fixtures/instanceT
 import { sourcesList, gcpSourcesList, awsSourceUploadInfo, gcpSourceUploadInfo } from './fixtures/sources.fixtures';
 import { pubkeysList } from './fixtures/pubkeys.fixtures';
 import { clonedImages, parentImage, successfulCloneStatus } from './fixtures/image.fixtures';
-import { AWSReservation, getAzureReservation, createdAWSReservation, createdAzureReservation, reservation } from './fixtures/reservation.fixtures';
+import {
+  AWSReservation,
+  getAzureReservation,
+  createdAWSReservation,
+  createdAzureReservation,
+  reservation,
+  createdGCPReservation,
+  GCPReservation,
+} from './fixtures/reservation.fixtures';
 import { templates } from './fixtures/templates.fixtures';
 
 export const handlers = [
@@ -45,6 +53,9 @@ export const handlers = [
   rest.post(provisioningUrl('reservations/azure'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(createdAzureReservation));
   }),
+  rest.post(provisioningUrl('reservations/gcp'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(createdGCPReservation));
+  }),
   rest.post(provisioningUrl('reservations/aws'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(createdAWSReservation));
   }),
@@ -56,6 +67,9 @@ export const handlers = [
   }),
   rest.get(provisioningUrl('reservations/azure/:id'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getAzureReservation));
+  }),
+  rest.get(provisioningUrl('reservations/gcp/:id'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(GCPReservation));
   }),
   rest.get(provisioningUrl('sources/:id/launch_templates'), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(templates));


### PR DESCRIPTION
This PR adds an instance description table at the end of a successful launch and also adds missing tests. 
![image](https://github.com/RHEnVision/provisioning-frontend/assets/57755873/77c8bce9-f214-4cb5-a0ef-3d68d8256ba2)
