### PR TITLE
fix(HMSPROV-2012): fix missing instances table

### DIFF
--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/index.js
@@ -91,7 +91,7 @@ const ReservationProgress = ({ setLaunchSuccess }) => {
 
   // polling request
   const { data: polledReservation } = useQuery(['reservation', reservationID], () => fetchReservation(reservationID), {
-    enabled: !!reservationID && currentStep < steps.length && !currentError,
+    enabled: !!reservationID && !currentError,
     staleTime: 0, // disable cache
     refetchInterval: (data) => {
       if (data?.success || !!data?.error) return false;


### PR DESCRIPTION
In some cases, a polled reservation might be set at its final step (i.e. step 3 out of 3), but the `success` flag is still null, this caused the frontend app to end up polling.

polled reservation:
```
{
    "id": 25,
    "provider": 2,
    "created_at": "2023-06-25T18:33:20.686045Z",
    "steps": 3,
    "step_titles": [
        "Ensure public key",
        "Launch instance(s)",
        "Fetch instance(s) description"
    ],
    "step": 3,
    "status": "Instance(s) description fetched",
    "error": "",
    "finished_at": null,
    "success": null
}
```
