### PR TITLE
feat(HMS-2022): Show DNS column only if public_dns(s) are not empty

### DIFF
--- a/src/Components/InstancesTable/index.js
+++ b/src/Components/InstancesTable/index.js
@@ -30,6 +30,7 @@ const InstancesTable = ({ reservationID, provider, region }) => {
   };
 
   const instancesPerPage = instances?.slice(paginationOptions.startIdx, paginationOptions.endIdx);
+  const atLeastOneDetailNotEmpty = instancesPerPage?.some((instance) => instance.detail?.public_dns?.length > 0);
 
   return (
     <Card style={{ position: 'relative', marginLeft: '-20%', marginRight: '-20%' }}>
@@ -47,7 +48,7 @@ const InstancesTable = ({ reservationID, provider, region }) => {
         <Thead>
           <Tr>
             <Th>ID</Th>
-            <Th>DNS</Th>
+            {atLeastOneDetailNotEmpty && <Th>DNS</Th>}
             <Th>SSH command</Th>
           </Tr>
         </Thead>
@@ -68,15 +69,17 @@ const InstancesTable = ({ reservationID, provider, region }) => {
                   {humanizeInstanceID(instance_id, provider)}
                 </Button>
               </Td>
-              <Td aria-label="instance dns" dataLabel="DNS">
-                {detail?.public_dns ? (
-                  <ClipboardCopy isReadOnly hoverTip="Copy DNS" clickTip="DNS was copied!" variant="expansion">
-                    {detail?.public_dns}
-                  </ClipboardCopy>
-                ) : (
-                  'N/A'
-                )}
-              </Td>
+              {atLeastOneDetailNotEmpty && (
+                <Td aria-label="instance dns" dataLabel="DNS">
+                  {detail?.public_dns ? (
+                    <ClipboardCopy isReadOnly hoverTip="Copy DNS" clickTip="DNS was copied!" variant="expansion">
+                      {detail?.public_dns}
+                    </ClipboardCopy>
+                  ) : (
+                    'N/A'
+                  )}
+                </Td>
+              )}
               <Td aria-label="ssh command" dataLabel="SSH">
                 {detail?.public_ipv4 ? (
                   <ClipboardCopy isReadOnly hoverTip="Copy SSH command" clickTip="SSH was copied!" variant="expansion">

--- a/src/Components/ProvisioningWizard/steps/ReservationProgress/ReservationProgress.test.js
+++ b/src/Components/ProvisioningWizard/steps/ReservationProgress/ReservationProgress.test.js
@@ -84,10 +84,8 @@ describe('Reservation polling', () => {
 
       // show table
       const instancesIDs = await screen.findAllByLabelText('instance id');
-      const instancesDNSs = await screen.findAllByLabelText('instance dns');
       const sshCommands = await screen.findAllByLabelText('ssh command');
       expect(instancesIDs).toHaveLength(getAzureReservation.instances.length);
-      expect(instancesDNSs).toHaveLength(getAzureReservation.instances.length);
 
       const instanceLink1 = getByRole(instancesIDs[0], 'link');
 
@@ -116,10 +114,8 @@ describe('Reservation polling', () => {
 
     // show table
     const instancesIDs = await screen.findAllByLabelText('instance id');
-    const instancesDNSs = await screen.findAllByLabelText('instance dns');
     const sshCommands = await screen.findAllByLabelText('ssh command');
     expect(instancesIDs).toHaveLength(GCPReservation.instances.length);
-    expect(instancesDNSs).toHaveLength(GCPReservation.instances.length);
 
     const instanceLink1 = getByRole(instancesIDs[0], 'link');
 


### PR DESCRIPTION
for GCP and Azure public DNS are not defined, this PR exposes the DNS column only if at least one launched instance has a public DNS defined. 
![image](https://github.com/RHEnVision/provisioning-frontend/assets/57755873/6be33810-5719-4df4-ab69-313f93053603)
