### PR TITLE
feat(HMS-1930): Add image command clipboard for GCP

### DIFF
--- a/src/Components/GCPConsoleLaunch/GCPConsoleLaunch.scss
+++ b/src/Components/GCPConsoleLaunch/GCPConsoleLaunch.scss
@@ -1,0 +1,3 @@
+.custom-clipboard-copy {
+    width: 600px;
+  }

--- a/src/Components/GCPConsoleLaunch/index.js
+++ b/src/Components/GCPConsoleLaunch/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ClipboardCopy, StackItem } from '@patternfly/react-core';
+import { imageProps } from '../ProvisioningWizard/helpers';
+import './GCPConsoleLaunch.scss';
+
+const launchInstanceCommand = (options) => {
+  return `gcloud compute instances create ${options.image_name}-instance --image-project ${options.project_id} --image ${options.image_name}`;
+};
+
+const GCPConsoleLaunch = ({ image }) => {
+  return (
+    <>
+      <br />
+      <p>or</p>
+      <br />
+      <StackItem>
+        <strong> Launch with Google Cloud Console </strong>
+      </StackItem>
+      <StackItem isFilled>
+        <ClipboardCopy
+          className="custom-clipboard-copy"
+          hoverTip="Copy"
+          clickTip="Copied"
+          ouiaId="gcp-launch-instance"
+          variant="expansion"
+          isReadOnly
+        >
+          {launchInstanceCommand(image.uploadStatus.options)}
+        </ClipboardCopy>
+      </StackItem>
+    </>
+  );
+};
+
+GCPConsoleLaunch.propTypes = {
+  image: imageProps,
+};
+
+export default GCPConsoleLaunch;

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -5,9 +5,9 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../../constants';
 import RegionsSelect from '../../../RegionsSelect';
 import { imageProps } from '../../helpers.js';
+import GCPConsoleLaunch from '../../../GCPConsoleLaunch';
 
 const DirectProviderLink = ({ image }) => {
-  // TODO gcp
   const uploadStatus = image.uploadStatus || { options: {} };
   const uploadOptions = image.uploadOptions || {};
   const [currentImage, setImage] = React.useState({ imageID: image.id, ...uploadStatus.options });
@@ -31,8 +31,6 @@ const DirectProviderLink = ({ image }) => {
         uploadStatus.options.image_name;
       break;
     case GCP_PROVIDER:
-      text = 'Launch with Google Cloud console';
-      url = 'https://console.cloud.google.com/welcome';
       break;
     default:
       throw new Error(`Steps requested for unknown provider: ${image.provider}`);
@@ -46,11 +44,15 @@ const DirectProviderLink = ({ image }) => {
 
   return (
     <Stack>
-      <StackItem>
-        <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>
-          {text}
-        </Button>
-      </StackItem>
+      {image.provider === GCP_PROVIDER ? (
+        <GCPConsoleLaunch image={image} />
+      ) : (
+        <StackItem>
+          <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>
+            {text}
+          </Button>
+        </StackItem>
+      )}
       {image.provider === AWS_PROVIDER && (
         <StackItem>
           <Bullseye>

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import SourceMissing from '.';
-
 import { render, screen } from '../../../../mocks/utils';
 import { awsImage, azureImage, gcpImage } from '../../../../mocks/fixtures/image.fixtures';
 
@@ -74,7 +72,7 @@ describe('Source missing', () => {
   describe('GCP', () => {
     const image = {
       ...gcpImage,
-      uploadStatus: { options: { image_name: 'cool-image' } },
+      uploadStatus: { options: { image_name: 'cool-image', project_id: 'test' } },
       uploadOptions: { accountIDs: 'example@redhat.com' },
     };
 
@@ -85,13 +83,16 @@ describe('Source missing', () => {
       expect(sourcesLink).toHaveAttribute('href', '/preview/settings/sources/new');
     });
 
-    test('renders direct link', () => {
+    it('renders the launch command', () => {
       render(<SourceMissing image={image} />);
 
-      const url = 'https://console.cloud.google.com/welcome';
+      const headingElement = screen.getByText(/Launch with Google Cloud Console/i);
+      expect(headingElement).toBeInTheDocument();
 
-      const directLink = screen.getByRole('link', { name: 'Launch with Google Cloud console' });
-      expect(directLink).toHaveAttribute('href', url);
+      const element = screen.getByRole('textbox', { name: 'Copyable input' });
+
+      expect(element).toHaveClass('pf-c-form-control');
+      expect(element).toHaveAttribute('value', 'gcloud compute instances create cool-image-instance --image-project test --image cool-image');
     });
   });
 });

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
@@ -8,10 +8,13 @@ import { imageProps } from '../../helpers.js';
 
 const failedToFetchTitle = 'Failed to fetch available sources.';
 const missingSourceTitle = 'No sources available';
-const missingSourceDescription =
-  'There are no sources available for use with this image. ' +
-  'Create a source, grant an existing source launch functionality, ' +
-  'or launch directly from the cloud provider console.';
+const missingSourceDescription = (
+  <>
+    <p>There are no sources available for use with this image.</p>
+    <p>Create a source, grant an existing source launch functionality,</p>
+    <p>or launch directly from the cloud provider console.</p>
+  </>
+);
 // TODO: enable once documentation is available.
 // Learn more about launching images [external link icon].
 


### PR DESCRIPTION
This PR adds launch instance command clipboard to GCP Empty state when there aren't any GCP sources available