### PR TITLE
ci: use older build container for pr_check

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -12,6 +12,9 @@ export APP_ROOT=$(pwd)
 # export NODE_BUILD_VERSION=16
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
+# The latest build container is broken for ephemeral builds now (bad Caddyfile)
+export BUILD_IMAGE_TAG="642ff08"
+
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------


### PR DESCRIPTION
The build container is now building into dist/stable folder. For PR_CHECK it does not tho, but the Caddyfile is still referencing this new folder.