### PR TITLE
fix(HMS-2297): clear key format error

### DIFF
--- a/src/Components/ProvisioningWizard/steps/Pubkeys/PubkeySelect.js
+++ b/src/Components/ProvisioningWizard/steps/Pubkeys/PubkeySelect.js
@@ -30,6 +30,7 @@ const PubkeySelect = ({ setStepValidated }) => {
       setIsKeySupported(false);
     } else {
       setStepValidated(!!selection);
+      setIsKeySupported(true);
     }
   }, [selection]);
 


### PR DESCRIPTION
When an invalid format for Azure key is selected, and then a valid (RSA) key is selected, the validation is not cleared, so it still seems like the key is not valid.