### PR TITLE
build: disable jest cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "PROXY=true ROUTES_PATH=config/routes.config.js fec dev",
     "start:stage": "PROXY=true fec dev",
     "start:federated": "fec static",
-    "test": "jest",
+    "test": "TZ=UTC jest --verbose --no-cache",
     "verify": "npm-run-all build lint test",
     "dev": "HOT=true PROXY=true ROUTES_PATH=config/routes.config.js fec dev --clouddotEnv stage --uiEnv beta"
   },


### PR DESCRIPTION
Part of the frontend containerization, jest needs to run with no-cache