### PR TITLE
fix(HMS-1913): add an optinal string to template select

### DIFF
--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/aws.js
@@ -115,7 +115,7 @@ const AccountCustomizationsAWS = ({ setStepValidated, image }) => {
         />
       </FormGroup>
       <FormGroup
-        label="Select template"
+        label="Select template (optional)"
         fieldId="aws-select-template"
         labelIcon={
           <Popover

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/gcp.js
@@ -112,7 +112,7 @@ const AccountCustomizationsGCP = ({ setStepValidated, image }) => {
         />
       </FormGroup>
       <FormGroup
-        label="Select template"
+        label="Select template (optional)"
         fieldId="gcp-select-template"
         labelIcon={
           <Popover


### PR DESCRIPTION
This PR Adds the word "Optional" to select templates field to better indicate that it is optional.

![Screen Shot 2023-08-27 at 16 37 53](https://github.com/RHEnVision/provisioning-frontend/assets/11807069/6858e402-6ca6-4f7a-8bf7-3d6a735ee70a)

Another solution is to use patternfly Form's `additionalLabel` prop:

![Screen Shot 2023-08-27 at 16 25 56](https://github.com/RHEnVision/provisioning-frontend/assets/11807069/c83d1fcf-456c-4252-ae84-29344e9d438c)

/cc @MariSvirik