### PR TITLE
feat(HMS-1897): add export to csv btn to instances table

### DIFF
--- a/src/Components/InstancesTable/helpers.js
+++ b/src/Components/InstancesTable/helpers.js
@@ -12,3 +12,29 @@ export const SSHUsername = (provider) => {
       '';
   }
 };
+
+const flattenInstances = (instances) => {
+  return instances.map(({ instance_id, detail }) => ({ id: instance_id, ...detail }));
+};
+const convertToCSV = (objArray) => {
+  const flatten = flattenInstances(objArray);
+  const header = Object.keys(flatten[0]);
+  const csv = flatten.map((row) => header.map((fieldName) => JSON.stringify(row[fieldName])).join(','));
+  csv.unshift(header.join(','));
+  return csv.join('\r\n');
+};
+
+export const exportToCSV = (data) => {
+  const csv = convertToCSV(data);
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.style.display = 'none';
+  a.href = url;
+  a.download = 'instances.csv';
+  document.body.appendChild(a);
+  a.click();
+
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+};

--- a/src/Components/InstancesTable/index.js
+++ b/src/Components/InstancesTable/index.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { Button, ClipboardCopy, Card, Pagination, Spinner, Bullseye } from '@patternfly/react-core';
+import { ExportIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Button, ClipboardCopy, Card, Pagination, Spinner, Bullseye, EmptyStatePrimary } from '@patternfly/react-core';
 import { useQuery } from '@tanstack/react-query';
 
-import { SSHUsername } from './helpers';
+import { SSHUsername, exportToCSV } from './helpers';
 import { instanceLink, humanizeInstanceID } from '../Common/instanceHelpers';
 import { fetchReservationByProvider } from '../../API';
 
@@ -39,67 +39,74 @@ const InstancesTable = ({ reservationID, provider, region }) => {
       </Bullseye>
     );
   return (
-    <Card style={{ position: 'relative', marginLeft: '-20%', marginRight: '-20%' }}>
-      <Pagination
-        itemCount={instances?.length || 0}
-        page={paginationOptions.page}
-        onSetPage={onSetPage}
-        perPage={paginationOptions.perPage}
-        onPerPageSelect={onPerPageSelect}
-        perPageOptions={PER_PAGE_OPTIONS}
-        isCompact
-        ouiaId="instances-pagination"
-      />
-      <TableComposable ouiaId="instances table" aria-label="instances description table" variant="compact">
-        <Thead>
-          <Tr>
-            <Th>ID</Th>
-            {atLeastOneDetailNotEmpty && <Th>DNS</Th>}
-            <Th>SSH command</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {instancesPerPage?.map(({ instance_id, detail }) => (
-            <Tr key={instance_id}>
-              <Td aria-label="instance id" dataLabel="ID">
-                <Button
-                  variant="link"
-                  icon={<ExternalLinkAltIcon />}
-                  iconPosition="right"
-                  isInline
-                  component="a"
-                  rel="noreferrer"
-                  target="_blank"
-                  href={instanceLink(instance_id, provider, region)}
-                >
-                  {humanizeInstanceID(instance_id, provider)}
-                </Button>
-              </Td>
-              {atLeastOneDetailNotEmpty && (
-                <Td aria-label="instance dns" dataLabel="DNS">
-                  {detail?.public_dns ? (
-                    <ClipboardCopy isReadOnly hoverTip="Copy DNS" clickTip="DNS was copied!" variant="expansion">
-                      {detail?.public_dns}
+    <>
+      <Card style={{ position: 'relative', marginLeft: '-20%', marginRight: '-20%' }}>
+        <Pagination
+          itemCount={instances?.length || 0}
+          page={paginationOptions.page}
+          onSetPage={onSetPage}
+          perPage={paginationOptions.perPage}
+          onPerPageSelect={onPerPageSelect}
+          perPageOptions={PER_PAGE_OPTIONS}
+          isCompact
+          ouiaId="instances-pagination"
+        />
+        <TableComposable ouiaId="instances table" aria-label="instances description table" variant="compact">
+          <Thead>
+            <Tr>
+              <Th>ID</Th>
+              {atLeastOneDetailNotEmpty && <Th>DNS</Th>}
+              <Th>SSH command</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {instancesPerPage?.map(({ instance_id, detail }) => (
+              <Tr key={instance_id}>
+                <Td aria-label="instance id" dataLabel="ID">
+                  <Button
+                    variant="link"
+                    icon={<ExternalLinkAltIcon />}
+                    iconPosition="right"
+                    isInline
+                    component="a"
+                    rel="noreferrer"
+                    target="_blank"
+                    href={instanceLink(instance_id, provider, region)}
+                  >
+                    {humanizeInstanceID(instance_id, provider)}
+                  </Button>
+                </Td>
+                {atLeastOneDetailNotEmpty && (
+                  <Td aria-label="instance dns" dataLabel="DNS">
+                    {detail?.public_dns ? (
+                      <ClipboardCopy isReadOnly hoverTip="Copy DNS" clickTip="DNS was copied!" variant="expansion">
+                        {detail?.public_dns}
+                      </ClipboardCopy>
+                    ) : (
+                      'N/A'
+                    )}
+                  </Td>
+                )}
+                <Td aria-label="ssh command" dataLabel="SSH">
+                  {detail?.public_ipv4 ? (
+                    <ClipboardCopy isReadOnly hoverTip="Copy SSH command" clickTip="SSH was copied!" variant="expansion">
+                      {`ssh ${SSHUsername(provider)}@${detail?.public_ipv4}`}
                     </ClipboardCopy>
                   ) : (
                     'N/A'
                   )}
                 </Td>
-              )}
-              <Td aria-label="ssh command" dataLabel="SSH">
-                {detail?.public_ipv4 ? (
-                  <ClipboardCopy isReadOnly hoverTip="Copy SSH command" clickTip="SSH was copied!" variant="expansion">
-                    {`ssh ${SSHUsername(provider)}@${detail?.public_ipv4}`}
-                  </ClipboardCopy>
-                ) : (
-                  'N/A'
-                )}
-              </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
-    </Card>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      </Card>
+      <EmptyStatePrimary>
+        <Button variant="link" icon={<ExportIcon />} iconPosition="left" onClick={() => exportToCSV(instances)}>
+          Export to CSV
+        </Button>
+      </EmptyStatePrimary>
+    </>
   );
 };
 


### PR DESCRIPTION
This adds an export to csv button to the instances table

![Screen Shot 2023-09-06 at 11 30 38](https://github.com/RHEnVision/provisioning-frontend/assets/11807069/a1153794-9c9f-4962-bebb-20f69bd4b3ac)

vs

![Screen Shot 2023-09-05 at 18 51 09](https://github.com/RHEnVision/provisioning-frontend/assets/11807069/2f9a8482-22e7-4260-9fd8-87729bbd09f3)
