### PR TITLE
build: use npm build instead of yarn

### DIFF
--- a/.github/workflows/provisioning-front.yml
+++ b/.github/workflows/provisioning-front.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm test
 
       - name: Run build
-        run: yarn build
+        run: npm run build
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
in GitHub action, we use yarn for building, but we use npm.