### PR TITLE
fix(HMS-2034): Unify missing source empty state

### DIFF
--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -5,7 +5,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../../constants';
 import RegionsSelect from '../../../RegionsSelect';
 import { imageProps } from '../../helpers.js';
-import GCPConsoleLaunch from '../../../GCPConsoleLaunch';
+import GCPConsoleLaunch from './GCPConsoleLaunch';
 
 const DirectProviderLink = ({ image }) => {
   const uploadStatus = image.uploadStatus || { options: {} };
@@ -31,21 +31,21 @@ const DirectProviderLink = ({ image }) => {
         uploadStatus.options.image_name;
       break;
     case GCP_PROVIDER:
+      text = 'Launch with Google Cloud Console';
       break;
     default:
       throw new Error(`Steps requested for unknown provider: ${image.provider}`);
   }
 
-  // Currently only AWS, so the ami is hardcoded
+  // Currently only used for AWS
   const onRegionChange = (image) => {
-    console.log(image);
     setImage(image);
   };
 
   return (
     <Stack>
       {image.provider === GCP_PROVIDER ? (
-        <GCPConsoleLaunch image={image} />
+        <GCPConsoleLaunch text={text} image={image} />
       ) : (
         <StackItem>
           <Button component="a" variant="link" icon={<ExternalLinkAltIcon />} iconPosition="right" target="_blank" href={url}>

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/GCPConsoleLaunch.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/GCPConsoleLaunch.js
@@ -1,20 +1,18 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { ClipboardCopy, StackItem } from '@patternfly/react-core';
-import { imageProps } from '../ProvisioningWizard/helpers';
+import { imageProps } from '../../helpers';
 import './GCPConsoleLaunch.scss';
 
 const launchInstanceCommand = (options) => {
   return `gcloud compute instances create ${options.image_name}-instance --image-project ${options.project_id} --image ${options.image_name}`;
 };
 
-const GCPConsoleLaunch = ({ image }) => {
+const GCPConsoleLaunch = ({ text, image }) => {
   return (
     <>
-      <br />
-      <p>or</p>
-      <br />
       <StackItem>
-        <strong> Launch with Google Cloud Console </strong>
+        <strong>{text}</strong>
       </StackItem>
       <StackItem isFilled>
         <ClipboardCopy
@@ -34,6 +32,7 @@ const GCPConsoleLaunch = ({ image }) => {
 
 GCPConsoleLaunch.propTypes = {
   image: imageProps,
+  text: PropTypes.string,
 };
 
 export default GCPConsoleLaunch;

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/GCPConsoleLaunch.scss
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/GCPConsoleLaunch.scss
@@ -1,3 +1,3 @@
 .custom-clipboard-copy {
-    width: 600px;
-  }
+  width: 600px;
+}

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.scss
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/SourceMissing.scss
@@ -1,0 +1,3 @@
+.sources-empty-state-divider {
+  padding: 15px 0;
+}

--- a/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/index.js
@@ -1,17 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateSecondaryActions, Title, Spinner } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  Title,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { PlusCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 import DirectProviderLink from './DirectProviderLink';
 import { imageProps } from '../../helpers.js';
+import './SourceMissing.scss';
 
 const failedToFetchTitle = 'Failed to fetch available sources.';
 const missingSourceTitle = 'No sources available';
 const missingSourceDescription = (
   <>
     <p>There are no sources available for use with this image.</p>
+    <p>Sources are used to link your cloud provider account and enable launching directly from Red Hat console.</p>
     <p>Create a source, grant an existing source launch functionality,</p>
     <p>or launch directly from the cloud provider console.</p>
   </>
@@ -41,7 +53,12 @@ const SourceMissing = ({ error, image }) => {
         Create Source
       </Button>
       <EmptyStateSecondaryActions>
-        <DirectProviderLink image={image} />
+        <Stack>
+          <StackItem className="sources-empty-state-divider">or</StackItem>
+          <StackItem>
+            <DirectProviderLink image={image} />
+          </StackItem>
+        </Stack>
       </EmptyStateSecondaryActions>
     </EmptyState>
   );

--- a/src/Components/RegionsSelect/index.js
+++ b/src/Components/RegionsSelect/index.js
@@ -30,7 +30,7 @@ const RegionsSelect = ({ provider, currentRegion, composeID, onChange }) => {
   const defaultRegion = { region: provider && defaultRegionByProvider(provider), id: composeID };
   const images = [defaultRegion];
   // filter successful clones images
-  if (clonesStatusQueries.length && clonesStatusQueries.every((cloneQuery) => cloneQuery.isLoading === false)) {
+  if (clonesStatusQueries.length && !isCloneStatusLoading) {
     const clonesStatus = clonesStatusQueries?.map((query) => query?.data);
     // enrich the cloned image data
     clonesStatus?.forEach((status, index) => {


### PR DESCRIPTION
Unifies the delimiter of DirectProviderLink.
Moves delimiter out of the DirectProviderLink for other usage (No Permissions).

GCP:
![Screenshot from 2023-09-14 12-53-40](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/c74813e8-6d3a-4b65-a525-6b8e71850fe9)
AWS:
![Screenshot from 2023-09-14 12-53-32](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/883b55b9-c2c8-4e29-8dd6-2607b8fb4665)


@adiabramovitch any reason we had the OR delimiter just for GCP?