### PR TITLE
fix(HMS-2618): format regions error correctly

### DIFF
--- a/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
+++ b/src/Components/ProvisioningWizard/steps/SourceMissing/DirectProviderLink.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Bullseye, Stack, StackItem } from '@patternfly/react-core';
+import { Button, FormGroup, Bullseye, Stack, StackItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER } from '../../../../constants';
@@ -56,7 +56,9 @@ const DirectProviderLink = ({ image }) => {
       {image.provider === AWS_PROVIDER && (
         <StackItem>
           <Bullseye>
-            <RegionsSelect composeID={image.id} provider={image.provider} currentRegion={currentImage.region} onChange={onRegionChange} />
+            <FormGroup>
+              <RegionsSelect composeID={image.id} provider={image.provider} currentRegion={currentImage.region} onChange={onRegionChange} />
+            </FormGroup>
           </Bullseye>
         </StackItem>
       )}

--- a/src/Components/RegionsSelect/index.js
+++ b/src/Components/RegionsSelect/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Alert, Select, SelectOption, Spinner } from '@patternfly/react-core';
+import { FormHelperText, HelperText, HelperTextItem, Select, SelectOption, Spinner } from '@patternfly/react-core';
 import { useQuery, useQueries } from '@tanstack/react-query';
 
 import { AWS_PROVIDER, AZURE_PROVIDER, GCP_PROVIDER, MULTIPLE_REGION_SUPPORT } from '../../constants';
@@ -53,8 +53,19 @@ const RegionsSelect = ({ provider, currentRegion, composeID, onChange }) => {
   if (isError) {
     return (
       <>
-        <Alert ouiaId="regions_alert" variant="warning" isInline title="There are problems fetching image's regions" />
-        <Select ouiaId="regions_empty" isDisabled placeholderText="No regions have been found" />
+        <Select
+          aria-label="Select region"
+          label="Select region"
+          validated="error"
+          ouiaId="regions_empty"
+          isDisabled
+          placeholderText="No regions have been found"
+        />
+        <FormHelperText isHidden={false} component="div">
+          <HelperText className="region-select-load-error">
+            <HelperTextItem variant="error">There are problems fetching available regions for this image.</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
       </>
     );
   }


### PR DESCRIPTION
Moves the error state on RegionSelect to use inline FormHelperText and error validations.

The fix itself is wrapping the RegionSelect in FormGroup.

BEFORE:
![Screenshot from 2023-09-20 09-14-16](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/c49612a9-f2d9-47ba-a426-a1372db8350b)

AFTER:
![Screenshot from 2023-09-20 09-52-10](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/980a2978-ba5a-4eb3-a7c6-54420a304c9b)
