### PR TITLE
build: add basic tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "target": "es5",
+    "allowSyntheticDefaultImports": true,
+    "noErrorTruncation": true,
+    "strict": true,
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "module": "esnext",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": [
+    "./src/entry.ts",
+    "./*.js",
+    "./*.d.ts"
+  ]
+}


### PR DESCRIPTION
The frontend config now requires a tsconfig for some reason. Probably update that got in too early.
This is just really basic tscript.json from template, to appease the plugin.

No idea why it's now needed, but shouldn't hurt :shrug: 