### PR TITLE
InstanceTypesSelect: improve arch compatibility

### DIFF
--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -4,7 +4,7 @@ import InstanceTypesSelect from '.';
 import { awsInstanceTypeList, azureInstanceTypeList } from '../../mocks/fixtures/instanceTypes.fixtures';
 import { render, screen } from '../../mocks/utils';
 
-describe('InstanceTypesSelect', () => {
+describe('InstanceTypesSelect x86_64', () => {
   test('populate AWS instance types select', async () => {
     await mountSelectAndClick();
     const items = await screen.findAllByLabelText(/^Instance Type/);
@@ -59,8 +59,29 @@ describe('InstanceTypesSelect', () => {
   });
 });
 
-const mountSelectAndClick = async (provider = 'aws') => {
-  render(<InstanceTypesSelect architecture="x86_64" setValidation={jest.fn()} />, {
+describe('test architecture mapping for instance selection', () => {
+  const X86_64 = 'x86_64';
+  const ARM64 = 'arm64';
+  const allX86s = ['x86-64', 'x86_64', 'x64'];
+  allX86s.forEach((x86) => {
+    test(x86, async () => {
+      await mountSelectAndClick('aws', x86);
+      const items = await screen.findAllByLabelText(/^Instance Type/);
+      expect(items).toHaveLength(awsInstanceTypeList.data.filter((type) => type.architecture === X86_64).length);
+    });
+  });
+  const allArch = ['aarch64', 'arm64', 'Arm64', 'arm'];
+  allArch.forEach((arm) => {
+    test(arm, async () => {
+      await mountSelectAndClick('aws', arm);
+      const items = await screen.findAllByLabelText(/^Instance Type/);
+      expect(items).toHaveLength(awsInstanceTypeList.data.filter((type) => type.architecture === ARM64).length);
+    });
+  });
+});
+
+const mountSelectAndClick = async (provider = 'aws', architecture = 'x86_64') => {
+  render(<InstanceTypesSelect architecture={architecture} setValidation={jest.fn()} />, {
     provider,
     contextValues: { chosenSource: '1' },
   });


### PR DESCRIPTION
Previously:
The InstanceTypesSelect would only show results for an architecture if the architecture returned by the backend was exactly matching the one asked by the user.

This proved to be problematic because some architecures can have many names. For instance `aarch64` can be interchangeably used with `arm64`.

To to make the ProvisionningWizard more flexible, the instance selection dropdown now is using the same name mapping for the architectures as the one found in the backend. See:
https://github.com/RHEnVision/provisioning-backend/blob/0f3abc7328ebda3314d7496544b019a36a061152/internal/clients/architecture.go#L25

This work is related to HMS-1135