### PR TITLE
feat(HMS-2255): deploy to image RG by default

### DIFF
--- a/src/Components/AzureResourceGroup/AzureResourceGroup.test.js
+++ b/src/Components/AzureResourceGroup/AzureResourceGroup.test.js
@@ -6,6 +6,12 @@ import { azureSourceUploadInfo } from '../../mocks/fixtures/sources.fixtures';
 import AzureResourceGroup from '.';
 
 describe('AzureResourceGroup', () => {
+  test('disables and prepopulates resource group select with  the default value', async () => {
+    const rgSelect = await mountSelectAndOpen('Image RG');
+    expect(rgSelect).toBeDisabled();
+    expect(rgSelect).toHaveValue('Image RG');
+  });
+
   test('populate resource group select', async () => {
     await mountSelectAndOpen();
     const items = await screen.findAllByLabelText(/^Resource group/);
@@ -29,8 +35,8 @@ describe('AzureResourceGroup', () => {
   });
 });
 
-const mountSelectAndOpen = async () => {
-  render(<AzureResourceGroup />, {
+const mountSelectAndOpen = async (imageResourceGroup = null) => {
+  render(<AzureResourceGroup imageResourceGroup={imageResourceGroup} />, {
     contextValues: { chosenSource: '66' },
   });
   const selectDropdown = await screen.findByLabelText('Select resource group');

--- a/src/Components/AzureResourceGroup/index.js
+++ b/src/Components/AzureResourceGroup/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Spinner, Select, SelectOption, TextInput } from '@patternfly/react-core';
@@ -6,10 +7,10 @@ import { AZURE_RG_KEY } from '../../API/queryKeys';
 import { fetchResourceGroups } from '../../API';
 import { useWizardContext } from '../Common/WizardContext';
 
-const AzureResourceGroup = () => {
+const AzureResourceGroup = ({ imageResourceGroup }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [{ chosenSource, azureResourceGroup }, setWizardContext] = useWizardContext();
-  const [selection, setSelection] = React.useState(azureResourceGroup);
+  const [selection, setSelection] = React.useState(azureResourceGroup || imageResourceGroup);
 
   const {
     isInitialLoading: isLoading,
@@ -17,7 +18,7 @@ const AzureResourceGroup = () => {
     data: resourceGroups,
   } = useQuery([AZURE_RG_KEY, chosenSource], () => fetchResourceGroups(chosenSource), {
     staleTime: 30 * 1000, // data is considered fresh for 30 seconds
-    enabled: !!chosenSource,
+    enabled: !!chosenSource && !imageResourceGroup,
   });
 
   if (!chosenSource || chosenSource === '') {
@@ -84,15 +85,24 @@ const AzureResourceGroup = () => {
       isOpen={isOpen}
       onClear={clearSelection}
       selections={selection}
-      placeholderText="redhat-deployed (default)"
+      isDisabled={!!imageResourceGroup}
+      placeholderText="(default) image resource group"
       typeAheadAriaLabel="Select resource group"
       maxHeight="220px"
     >
-      {resourceGroups.map((name, idx) => (
+      {(resourceGroups || [selection]).map((name, idx) => (
         <SelectOption aria-label={`Resource group ${name}`} key={idx} value={name} />
       ))}
     </Select>
   );
+};
+
+AzureResourceGroup.propTypes = {
+  imageResourceGroup: PropTypes.string,
+};
+
+AzureResourceGroup.defaultProps = {
+  imageResourceGroup: null,
 };
 
 export default AzureResourceGroup;

--- a/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
+++ b/src/Components/ProvisioningWizard/steps/AccountCustomizations/azure.js
@@ -3,17 +3,15 @@ import React from 'react';
 import { Form, FormGroup, Popover, Title, Button, Text } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
-import { AZURE_PROVIDER } from '../../../../constants';
 import { imageProps } from '../../helpers';
 import SourcesSelect from '../../../SourcesSelect';
 import InstanceCounter from '../../../InstanceCounter';
 import InstanceTypesSelect from '../../../InstanceTypesSelect';
-import RegionsSelect from '../../../RegionsSelect';
 import AzureResourceGroup from '../../../AzureResourceGroup';
 import { useWizardContext } from '../../../Common/WizardContext';
 
 const AccountCustomizationsAzure = ({ setStepValidated, image }) => {
-  const [wizardContext, setWizardContext] = useWizardContext();
+  const [wizardContext] = useWizardContext();
   const [validations, setValidation] = React.useState({
     sources: wizardContext.chosenSource ? 'success' : 'default',
     types: wizardContext.chosenInstanceType ? 'success' : 'default',
@@ -25,14 +23,6 @@ const AccountCustomizationsAzure = ({ setStepValidated, image }) => {
     const errorExists = Object.values(validations).some((valid) => valid == 'error' || valid == 'default');
     setStepValidated(!errorExists);
   }, [validations]);
-
-  const onRegionChange = ({ region, imageID }) => {
-    setWizardContext((prevState) => ({
-      ...prevState,
-      chosenRegion: region,
-      chosenImageID: imageID,
-    }));
-  };
 
   return (
     <Form>
@@ -57,34 +47,17 @@ const AccountCustomizationsAzure = ({ setStepValidated, image }) => {
         />
       </FormGroup>
       <FormGroup
-        label="Select location"
-        isRequired
-        fieldId="azure-select-location"
-        labelIcon={
-          <Popover headerContent={<div>Azure locations</div>}>
-            <Button
-              ouiaId="location_help"
-              type="button"
-              aria-label="More info for location field"
-              onClick={(e) => e.preventDefault()}
-              aria-describedby="azure-select-location"
-              className="pf-c-form__group-label-help"
-              variant="plain"
-            >
-              <HelpIcon noVerticalAlign />
-            </Button>
-          </Popover>
-        }
-      >
-        <RegionsSelect provider={AZURE_PROVIDER} currentRegion={wizardContext.chosenRegion} onChange={onRegionChange} composeID={image.id} />
-      </FormGroup>
-      <FormGroup
         label="Azure resource group"
         fieldId="azure-resource-group-select"
         labelIcon={
           <Popover
             headerContent={<div>Azure resource group</div>}
-            bodyContent={<div>Azure resource group to deploy the VM resources into. If left blank, defaults to &lsquo;redhat-deployed&rsquo;.</div>}
+            bodyContent={
+              <div>
+                <p>Azure resource group to deploy the VM resources into. Defaults to the resource group image is located in.</p>
+                <p>The location (Azure region) of the resource group is used for all resources deployed.</p>
+              </div>
+            }
           >
             <Button
               ouiaId="resource_group_help"
@@ -100,7 +73,7 @@ const AccountCustomizationsAzure = ({ setStepValidated, image }) => {
           </Popover>
         }
       >
-        <AzureResourceGroup />
+        <AzureResourceGroup imageResourceGroup={image.uploadOptions?.resource_group} />
       </FormGroup>
       <FormGroup
         label="Select instance size"


### PR DESCRIPTION
Use image RG by default, we disable selection of resource group entirely  for now.

This also removes the disabled region selection, as we default to the  Resource Group location(region) and that's the best practice in Azure,  so we don't want to promote overriding it.

Previously:
![Screenshot from 2023-10-24 14-48-38](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/7ce5bdff-70d0-40fc-96e3-c9a8c1c4a68e)

Now:
![Screenshot from 2023-10-24 14-47-56](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/dd5ad38a-047f-4003-b6ad-093d939a9163)
