### PR TITLE
docs: make notification tip expandable to take less space

### DIFF
--- a/src/Components/ProvisioningWizard/steps/ReviewDetails/index.js
+++ b/src/Components/ProvisioningWizard/steps/ReviewDetails/index.js
@@ -18,8 +18,9 @@ const ReviewDetails = ({ imageName }) => {
       {showNotificationBanner && (
         <Alert
           variant="info"
+          isExpandable
           isInline
-          title="Notification integration"
+          title="Get notified on finished Launch by email, webhook or slack"
           actionLinks={[
             <AlertActionLink
               key="more_details_btn"


### PR DESCRIPTION
I've also reworded it to be more "call to action" title, given now less people will see the body.

![image](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/f9578474-a9c9-4b61-928a-6398144601bc)
