### PR TITLE
fix: do not show region in review for Azure provider

### DIFF
--- a/src/Components/LaunchDescriptionList/index.js
+++ b/src/Components/LaunchDescriptionList/index.js
@@ -53,16 +53,17 @@ const LaunchDescriptionList = ({ image }) => {
           <DescriptionListTerm>Account</DescriptionListTerm>
           <DescriptionListDescription>{getChosenSourceName()}</DescriptionListDescription>
         </DescriptionListGroup>
-        {provider === AZURE_PROVIDER && (
+        {(provider === AZURE_PROVIDER && (
           <DescriptionListGroup>
             <DescriptionListTerm>Resource group</DescriptionListTerm>
             <DescriptionListDescription>{azureResourceGroup || <i>{imageAzureResourceGroup(image)}</i>}</DescriptionListDescription>
           </DescriptionListGroup>
+        )) || (
+          <DescriptionListGroup>
+            <DescriptionListTerm>{regionLabel}</DescriptionListTerm>
+            <DescriptionListDescription>{chosenRegion}</DescriptionListDescription>
+          </DescriptionListGroup>
         )}
-        <DescriptionListGroup>
-          <DescriptionListTerm>{regionLabel}</DescriptionListTerm>
-          <DescriptionListDescription>{chosenRegion}</DescriptionListDescription>
-        </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{instanceTypeLabel}</DescriptionListTerm>
           <DescriptionListDescription>{chosenInstanceType}</DescriptionListDescription>


### PR DESCRIPTION
Removes region info from Review for Azure.
For Azure we use Resource Group insted.

![image](https://github.com/RHEnVision/provisioning-frontend/assets/2884324/399b5a11-3857-48dd-b66c-c6077c59f1c0)


Refs HMS-2255