### PR TITLE
fix(HMS-3593): Added unit test cases for instance type selection

### DIFF
--- a/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
+++ b/src/Components/InstanceTypesSelect/InstanceTypesSelect.test.js
@@ -49,12 +49,34 @@ describe('InstanceTypesSelect x86_64', () => {
       const items = await screen.findAllByLabelText(/^Instance Type/);
       expect(items).toHaveLength(1);
     });
-    test('filter with a query', async () => {
-      const query = 'vcpus > 2 and cores > 2';
+    test('filter with a query greater than', async () => {
+      const query = 'vcpus > 2 and cores > 2 and memory > 1024';
       const dropdown = await mountSelectAndClick();
       await userEvent.type(dropdown, query);
       const items = await screen.findAllByLabelText(/^Instance Type/);
       expect(items).toHaveLength(1);
+    });
+    test('filter with a query less than', async () => {
+      const query = 'vcpus < 2 and cores < 2 and memory < 1024';
+      const dropdown = await mountSelectAndClick();
+      await userEvent.type(dropdown, query);
+      const items = await screen.findAllByLabelText(/^Instance Type/);
+      expect(items).toHaveLength(1);
+    });
+    test('filter with a query combination', async () => {
+      const query = 'vcpus < 3 and cores > 1 and memory = 1024';
+      const dropdown = await mountSelectAndClick();
+      await userEvent.type(dropdown, query);
+      const input = await screen.findByLabelText('Selected instance type');
+      expect(input).toBeInTheDocument();
+    });
+    test('filter with a query equal', async () => {
+      const query = 'vcpus = 2 and cores = 2 and memory = 1024';
+      const dropdown = await mountSelectAndClick();
+      await userEvent.type(dropdown, query);
+      const inputs = await screen.findAllByLabelText('Selected instance type');
+      expect(inputs.length).toBe(1);
+      expect(inputs[0]).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
This PR adds unit test cases to verify the filtering functionality of the application. The test cases cover different scenarios, including filtering with queries greater than, less than, equal to, and combinations.

Local execution results :
```
npm test -- --testNamePattern="filter with a query greater than|filter with a query less than|filter with a query combination|filter with a query equal"

Test Suites: 11 skipped, 1 passed, 1 of 12 total
Tests:       53 skipped, 4 passed, 57 total
Snapshots:   0 total
Time:        36.834 s
Ran all test suites with tests matching "filter with a query greater than|filter with a query less than|filter with a query combination|filter with a query equal".
```

