### PR TITLE
build: Disable relative import lint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,3 +4,6 @@ globals:
   shallow: readonly
   render: 'readonly'
   mount: 'readonly'
+rules:
+  # We are transforming the imports in babel, so we don't need to enforce this rule
+  rulesdir/forbid-pf-relative-imports: 'off'


### PR DESCRIPTION
We are using babel to transform the relative pf imports, we do not need to use relative lints explicitly.

Disabling the lint is needed in that case not to force us out of the relative lints.

The transformation happens here: https://github.com/RHEnVision/provisioning-frontend/blob/408b056951f8e60cc1829d1b13b05162e3593020/babel.config.js#L44